### PR TITLE
fix: avoid Dexie global version conflict

### DIFF
--- a/apps/obsidian-plugin/src/sync/store/dexie/database.ts
+++ b/apps/obsidian-plugin/src/sync/store/dexie/database.ts
@@ -1,4 +1,8 @@
-import Dexie, { type Table } from "dexie";
+import type { Table } from "dexie";
+// Import the Dexie ESM build directly. The package root uses a global singleton
+// wrapper that can throw when another Obsidian plugin has loaded a different
+// Dexie version in the same app window.
+import Dexie from "dexie/dist/dexie.mjs";
 
 import type { BlobRecord, EntryRecord, MetadataRecord } from "./records";
 

--- a/apps/obsidian-plugin/src/sync/store/dexie/database.ts
+++ b/apps/obsidian-plugin/src/sync/store/dexie/database.ts
@@ -1,8 +1,7 @@
-import type { Table } from "dexie";
 // Import the Dexie ESM build directly. The package root uses a global singleton
 // wrapper that can throw when another Obsidian plugin has loaded a different
 // Dexie version in the same app window.
-import Dexie from "dexie/dist/dexie.mjs";
+import Dexie, { type Table } from "dexie/dist/dexie.mjs";
 
 import type { BlobRecord, EntryRecord, MetadataRecord } from "./records";
 

--- a/apps/obsidian-plugin/src/sync/store/dexie/index.ts
+++ b/apps/obsidian-plugin/src/sync/store/dexie/index.ts
@@ -1,4 +1,7 @@
-import Dexie from "dexie";
+// Import the Dexie ESM build directly. The package root uses a global singleton
+// wrapper that can throw when another Obsidian plugin has loaded a different
+// Dexie version in the same app window.
+import Dexie from "dexie/dist/dexie.mjs";
 import type { Plugin } from "obsidian";
 
 import { METADATA_ID, SyncDexieDatabase, syncStoreDbName } from "./database";

--- a/apps/obsidian-plugin/src/types/dexie-dist.d.ts
+++ b/apps/obsidian-plugin/src/types/dexie-dist.d.ts
@@ -1,0 +1,4 @@
+declare module "dexie/dist/dexie.mjs" {
+  export * from "dexie";
+  export { default } from "dexie";
+}


### PR DESCRIPTION
## Summary
- import Dexie from the ESM dist build to avoid the package root global singleton wrapper
- add a local declaration for the Dexie dist module import
- document why the Obsidian plugin bypasses the package root import

Refs #1

## Testing
- pnpm -C apps/obsidian-plugin typecheck

## Notes
- A production build bundled successfully during review, then failed only while copying artifacts into an Obsidian plugin directory outside the workspace sandbox.