### PR TITLE
feat(plugin): 제외 폴더 토글이 하위 폴더까지 적용되도록 개선

### DIFF
--- a/apps/obsidian-plugin/src/i18n.ts
+++ b/apps/obsidian-plugin/src/i18n.ts
@@ -34,6 +34,8 @@ const messages = {
     "excluded.count": ({ count }: { count: number }) => `${count} folder${count === 1 ? "" : "s"} excluded on this device.`,
     "excluded.folderDesc": "Excluded from sync on this device.",
     "excluded.header": "Excluded folders",
+    "excluded.inherited": ({ parent }: { parent: string }) =>
+      `Inherited from "${parent}".`,
     "excluded.none": "No excluded folders on this device.",
     "excluded.remove": "Remove",
     "excluded.selectHint": "Select folders that should never sync from this device.",
@@ -179,6 +181,8 @@ const messages = {
     "excluded.count": ({ count }: { count: number }) => `이 기기에서 ${count}개 폴더가 제외되었습니다.`,
     "excluded.folderDesc": "이 기기에서 동기화 제외됨.",
     "excluded.header": "제외된 폴더",
+    "excluded.inherited": ({ parent }: { parent: string }) =>
+      `상위 폴더 "${parent}"에 의해 제외됨.`,
     "excluded.none": "이 기기에서 제외된 폴더가 없습니다.",
     "excluded.remove": "제거",
     "excluded.selectHint": "이 기기에서 절대 동기화하지 않을 폴더를 선택하세요.",

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
@@ -2,39 +2,41 @@ import { describe, expect, it } from "vitest";
 
 import { findCoveringParent } from "./modals";
 
+const sortByDepthAsc = (folders: string[]): string[] =>
+  [...folders].sort((left, right) => left.length - right.length);
+
 describe("findCoveringParent", () => {
   it("returns null when no other folder covers the input", () => {
-    const selected = new Set(["Bar", "Baz"]);
-    expect(findCoveringParent("Foo", selected)).toBeNull();
+    expect(findCoveringParent("Foo", sortByDepthAsc(["Bar", "Baz"]))).toBeNull();
   });
 
   it("returns the covering ancestor when one is selected", () => {
-    const selected = new Set(["Foo"]);
-    expect(findCoveringParent("Foo/Bar", selected)).toBe("Foo");
+    expect(findCoveringParent("Foo/Bar", sortByDepthAsc(["Foo"]))).toBe("Foo");
   });
 
   it("does not treat a folder as its own parent", () => {
-    const selected = new Set(["Foo"]);
-    expect(findCoveringParent("Foo", selected)).toBeNull();
+    expect(findCoveringParent("Foo", sortByDepthAsc(["Foo"]))).toBeNull();
   });
 
   it("does not treat lookalike siblings as ancestors", () => {
-    const selected = new Set(["Foo"]);
-    expect(findCoveringParent("Foobar", selected)).toBeNull();
+    expect(findCoveringParent("Foobar", sortByDepthAsc(["Foo"]))).toBeNull();
   });
 
   it("finds the ancestor across multiple selected entries", () => {
-    const selected = new Set(["Bar", "Foo", "Baz"]);
-    expect(findCoveringParent("Foo/Sub/Deep", selected)).toBe("Foo");
+    expect(
+      findCoveringParent("Foo/Sub/Deep", sortByDepthAsc(["Bar", "Foo", "Baz"])),
+    ).toBe("Foo");
   });
 
   it("returns the topmost ancestor when several ancestors are selected", () => {
-    const selected = new Set(["Foo/Bar", "Foo"]);
-    expect(findCoveringParent("Foo/Bar/Baz", selected)).toBe("Foo");
+    expect(
+      findCoveringParent("Foo/Bar/Baz", sortByDepthAsc(["Foo/Bar", "Foo"])),
+    ).toBe("Foo");
   });
 
   it("returns the ancestor even when the input itself is selected", () => {
-    const selected = new Set(["Foo", "Foo/Bar"]);
-    expect(findCoveringParent("Foo/Bar", selected)).toBe("Foo");
+    expect(
+      findCoveringParent("Foo/Bar", sortByDepthAsc(["Foo", "Foo/Bar"])),
+    ).toBe("Foo");
   });
 });

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { findCoveringParent } from "./modals";
+
+describe("findCoveringParent", () => {
+  it("returns null when no other folder covers the input", () => {
+    const selected = new Set(["Bar", "Baz"]);
+    expect(findCoveringParent("Foo", selected)).toBeNull();
+  });
+
+  it("returns the covering ancestor when one is selected", () => {
+    const selected = new Set(["Foo"]);
+    expect(findCoveringParent("Foo/Bar", selected)).toBe("Foo");
+  });
+
+  it("does not treat a folder as its own parent", () => {
+    const selected = new Set(["Foo"]);
+    expect(findCoveringParent("Foo", selected)).toBeNull();
+  });
+
+  it("does not treat lookalike siblings as ancestors", () => {
+    const selected = new Set(["Foo"]);
+    expect(findCoveringParent("Foobar", selected)).toBeNull();
+  });
+
+  it("finds the ancestor across multiple selected entries", () => {
+    const selected = new Set(["Bar", "Foo", "Baz"]);
+    expect(findCoveringParent("Foo/Sub/Deep", selected)).toBe("Foo");
+  });
+});

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts
@@ -27,4 +27,14 @@ describe("findCoveringParent", () => {
     const selected = new Set(["Bar", "Foo", "Baz"]);
     expect(findCoveringParent("Foo/Sub/Deep", selected)).toBe("Foo");
   });
+
+  it("returns the topmost ancestor when several ancestors are selected", () => {
+    const selected = new Set(["Foo/Bar", "Foo"]);
+    expect(findCoveringParent("Foo/Bar/Baz", selected)).toBe("Foo");
+  });
+
+  it("returns the ancestor even when the input itself is selected", () => {
+    const selected = new Set(["Foo", "Foo/Bar"]);
+    expect(findCoveringParent("Foo/Bar", selected)).toBe("Foo");
+  });
 });

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
@@ -43,47 +43,71 @@ export class ExcludedFoldersModal extends Modal {
   }
 
   onOpen(): void {
+    this.render();
+  }
+
+  private render(): void {
     const { contentEl } = this;
     contentEl.empty();
-    new Setting(contentEl).setName(t("excluded.header")).setHeading();
-    contentEl.createEl("p", {
-      text: t("excluded.selectHint"),
+    new Setting(contentEl).setName(t('excluded.header')).setHeading();
+    contentEl.createEl('p', {
+      text: t('excluded.selectHint'),
     });
 
     if (this.options.availableFolders.length === 0) {
-      contentEl.createEl("p", {
-        text: t("excluded.availableEmpty"),
+      contentEl.createEl('p', {
+        text: t('excluded.availableEmpty'),
       });
     } else {
       for (const folder of this.options.availableFolders) {
-        new Setting(contentEl)
-          .setName(folder)
-          .addToggle((toggle) =>
-            toggle.setValue(this.selectedFolders.has(folder)).onChange((value) => {
-              if (value) {
-                this.selectedFolders.add(folder);
-              } else {
-                this.selectedFolders.delete(folder);
-              }
-            }),
+        const inheritedFrom = findCoveringParent(folder, this.selectedFolders);
+        const isInherited = inheritedFrom !== null;
+        const isOn = isInherited || this.selectedFolders.has(folder);
+
+        const setting = new Setting(contentEl).setName(folder);
+        if (isInherited) {
+          setting.setDesc(
+            t('excluded.inherited', { parent: inheritedFrom as string }),
           );
+        }
+        setting.addToggle((toggle) =>
+          toggle
+            .setValue(isOn)
+            .setDisabled(isInherited)
+            .onChange((value) => this.handleToggle(folder, value)),
+        );
       }
     }
 
     new Setting(contentEl)
       .addButton((button) =>
-        button.setButtonText(t("cancel")).onClick(() => {
+        button.setButtonText(t('cancel')).onClick(() => {
           this.close();
         }),
       )
       .addButton((button) =>
-        button.setButtonText(t("done")).setCta().onClick(() => {
+        button.setButtonText(t('done')).setCta().onClick(() => {
           void this.options.onSubmit(
             [...this.selectedFolders].sort((a, b) => a.localeCompare(b)),
           );
           this.close();
         }),
       );
+  }
+
+  private handleToggle(folder: string, value: boolean): void {
+    if (value) {
+      this.selectedFolders.add(folder);
+      const prefix = `${folder}/`;
+      for (const candidate of [...this.selectedFolders]) {
+        if (candidate !== folder && candidate.startsWith(prefix)) {
+          this.selectedFolders.delete(candidate);
+        }
+      }
+    } else {
+      this.selectedFolders.delete(folder);
+    }
+    this.render();
   }
 }
 

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
@@ -16,10 +16,9 @@ const MAX_DELETED_FILES_RESTORE_SELECTION = 100;
 
 export function findCoveringParent(
   folder: string,
-  selected: ReadonlySet<string>,
+  sortedSelected: readonly string[],
 ): string | null {
-  const topmostFirst = [...selected].sort((left, right) => left.length - right.length);
-  for (const candidate of topmostFirst) {
+  for (const candidate of sortedSelected) {
     if (folder !== candidate && folder.startsWith(`${candidate}/`)) {
       return candidate;
     }
@@ -59,8 +58,11 @@ export class ExcludedFoldersModal extends Modal {
         text: t('excluded.availableEmpty'),
       });
     } else {
+      const sortedSelected = [...this.selectedFolders].sort(
+        (left, right) => left.length - right.length,
+      );
       for (const folder of this.options.availableFolders) {
-        const inheritedFrom = findCoveringParent(folder, this.selectedFolders);
+        const inheritedFrom = findCoveringParent(folder, sortedSelected);
         const isInherited = inheritedFrom !== null;
         const isOn = isInherited || this.selectedFolders.has(folder);
 

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
@@ -14,6 +14,18 @@ import { formatDeletedFileTimestamp } from "./format";
 const DELETED_FILES_PAGE_SIZE = 25;
 const MAX_DELETED_FILES_RESTORE_SELECTION = 100;
 
+export function findCoveringParent(
+  folder: string,
+  selected: ReadonlySet<string>,
+): string | null {
+  for (const candidate of selected) {
+    if (folder !== candidate && folder.startsWith(`${candidate}/`)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 export class ExcludedFoldersModal extends Modal {
   private readonly selectedFolders: Set<string>;
 

--- a/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
+++ b/apps/obsidian-plugin/src/settings/settings-tab/modals.ts
@@ -18,7 +18,8 @@ export function findCoveringParent(
   folder: string,
   selected: ReadonlySet<string>,
 ): string | null {
-  for (const candidate of selected) {
+  const topmostFirst = [...selected].sort((left, right) => left.length - right.length);
+  for (const candidate of topmostFirst) {
     if (folder !== candidate && folder.startsWith(`${candidate}/`)) {
       return candidate;
     }

--- a/apps/obsidian-plugin/src/sync/core/file-rules.test.ts
+++ b/apps/obsidian-plugin/src/sync/core/file-rules.test.ts
@@ -97,4 +97,30 @@ describe("normalizeExcludedFolders", () => {
       ]),
     ).toEqual(["Archive", "Attachments/raw"]);
   });
+
+  it("removes descendants when their ancestor is also excluded", () => {
+    expect(normalizeExcludedFolders(["Foo", "Foo/Bar"])).toEqual(["Foo"]);
+  });
+
+  it("keeps independent siblings", () => {
+    expect(normalizeExcludedFolders(["Foo", "Bar"])).toEqual(["Bar", "Foo"]);
+  });
+
+  it("collapses multi-level descendants under the topmost ancestor", () => {
+    expect(normalizeExcludedFolders(["A", "A/B", "A/B/C", "D"])).toEqual([
+      "A",
+      "D",
+    ]);
+  });
+
+  it("does not treat lookalike siblings as descendants", () => {
+    expect(normalizeExcludedFolders(["Foo", "Foobar"])).toEqual([
+      "Foo",
+      "Foobar",
+    ]);
+  });
+
+  it("prunes regardless of input order", () => {
+    expect(normalizeExcludedFolders(["Foo/Bar", "Foo"])).toEqual(["Foo"]);
+  });
 });

--- a/apps/obsidian-plugin/src/sync/core/file-rules.ts
+++ b/apps/obsidian-plugin/src/sync/core/file-rules.ts
@@ -118,11 +118,25 @@ export function normalizeExcludedFolders(value: unknown): string[] {
     seen.add(normalized);
   }
 
-  return [...seen].sort((left, right) => left.localeCompare(right));
+  const sorted = [...seen].sort((left, right) => left.localeCompare(right));
+  return pruneSubpaths(sorted);
 }
 
 export function normalizeVaultPath(path: string): string {
   return path.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+}
+
+function pruneSubpaths(sortedPaths: readonly string[]): string[] {
+  const result: string[] = [];
+  for (const path of sortedPaths) {
+    const coveredByExisting = result.some((parent) =>
+      path.startsWith(`${parent}/`),
+    );
+    if (!coveredByExisting) {
+      result.push(path);
+    }
+  }
+  return result;
 }
 
 function isExcludedByFolder(path: string, excludedFolders: ReadonlyArray<string>): boolean {


### PR DESCRIPTION
## 개요

`ExcludedFoldersModal`에서 폴더 하나하나가 독립 토글이라 부모 폴더를 제외해도 자식 폴더 토글은 그대로 OFF로 보였습니다. 매칭 레이어(`isExcludedByFolder`)는 이미 prefix 매칭으로 자식까지 동기화에서 제외하지만, UI가 그 의미를 반영하지 못해 사용자가 혼란을 겪을 수 있고 `excludedFolders`에 의미 없는 자식 항목이 영구 저장되는 문제가 있었습니다.

이 PR은 모달이 매칭 레이어와 동일한 prefix 의미를 그대로 보여주도록 정리합니다.

## 변경 내용

- **부모 토글 ON 시 자식들이 자동 ON + disabled로 전환**되고, 설명에 `Inherited from "<상위 폴더>".`(영어) / `상위 폴더 "<상위 폴더>"에 의해 제외됨.`(한국어) 힌트가 표시됩니다.
- **부모 토글 OFF 시 자식들은 OFF + enabled로 복귀**합니다 (자식별 이전 선택은 기억하지 않는 단순화).
- `normalizeExcludedFolders`가 저장 시 **자식 경로를 prefix로 잡아 minimal 최상위 집합으로 정규화**합니다. 결과적으로 외부 Excluded folders 섹션에는 상위 폴더 하나만 Remove 버튼과 함께 표시되고, 기존 사용자가 갖고 있던 `["Foo", "Foo/Bar"]` 같은 중복 데이터는 다음 저장 시 자동으로 `["Foo"]`로 collapse 됩니다.
- 다중 ancestor가 in-flight 선택에 동시에 존재할 때 **가장 위쪽(가장 짧은 경로) 부모를 inherited 표시 대상으로 선택**하도록 `findCoveringParent`에 길이 기준 정렬 추가 — 사용자에게 보이는 힌트가 직관적인 폴더를 가리키도록.

## 디자인 결정

- **데이터 모델 변경 없음 / 마이그레이션 없음.** `SyncFileRules.excludedFolders: string[]`은 그대로이고, 매칭 로직(`shouldSyncPath`, `isExcludedByFolder`)도 손대지 않았습니다. sync engine 레이어(`vault-adapter`, `vault-files`, `local-reconcile-service`, `remote-vault-controller`, `version-history-controller`)는 영향이 없습니다.
- **트리 UI로 재구성하지 않음.** 평면 리스트는 그대로 두고 토글 동작과 힌트 표시만 바꿉니다 (UX 의도는 동일하면서 변경량이 작습니다).

## 추가 / 수정된 파일

- `apps/obsidian-plugin/src/sync/core/file-rules.ts` — `pruneSubpaths` 헬퍼 + 정규화 로직
- `apps/obsidian-plugin/src/sync/core/file-rules.test.ts` — cascade 정규화 5개 케이스
- `apps/obsidian-plugin/src/settings/settings-tab/modals.ts` — `findCoveringParent` 모듈 export, `ExcludedFoldersModal`을 `render()` + `handleToggle()` 패턴으로 리팩토링
- `apps/obsidian-plugin/src/settings/settings-tab/modals.test.ts` (신규) — `findCoveringParent` 7개 단위 테스트
- `apps/obsidian-plugin/src/i18n.ts` — `excluded.inherited` 키 (영/한)

## Test Plan

- [x] `pnpm -C apps/obsidian-plugin test --run` — 361/361 통과
- [x] `pnpm -C apps/obsidian-plugin typecheck` — 깨끗함
- [x] `API_BASE_URL=https://api.synch.run pnpm -C apps/obsidian-plugin build` — 성공 (324KB)
- [x] 실제 Obsidian vault에서 수동 검증 — 6단계 시나리오 모두 통과
  - 부모 ON 시 자식들 ON+disabled + inherited 힌트
  - 부모 OFF 시 자식들 OFF+enabled로 복귀
  - 자식만 ON 후 부모 ON → Done → 재오픈 시 자식이 inherited 표시
  - 외부 Excluded folders 섹션에 상위 폴더만 Remove 버튼 행으로 노출
  - Lookalike sibling(`Foo` ON 상태에서 `Foobar`)은 여전히 OFF + 사용자 조작 가능