### PR TITLE
Fix API logo home links

### DIFF
--- a/apps/api/public/device.html
+++ b/apps/api/public/device.html
@@ -18,7 +18,7 @@
 	<body class="bg-[#0a0a0a] text-zinc-400 font-sans antialiased min-h-screen flex flex-col text-sm">
 		<div class="max-w-3xl mx-auto px-6 w-full flex-1 flex flex-col justify-center py-12 sm:py-24">
 			<div class="mb-8 text-center">
-				<a href="/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
+				<a href="https://synch.run/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
 				<h1 class="text-2xl text-zinc-200 tracking-tight mb-2" data-i18n="title">Finish Synch sign-in in Obsidian</h1>
 				<p class="text-zinc-500 text-xs mb-2" data-i18n="subtitle">Approve the sign-in request opened by the Synch Obsidian plugin.</p>
 				<p class="text-zinc-500 text-xs" data-i18n="hint">Only continue if you just chose "Sign in on this device" in Obsidian.</p>

--- a/apps/api/public/signin.html
+++ b/apps/api/public/signin.html
@@ -16,7 +16,7 @@
 	<body class="bg-[#0a0a0a] text-zinc-400 font-sans antialiased min-h-screen flex flex-col text-sm">
 		<div class="max-w-md mx-auto px-6 w-full flex-1 flex flex-col justify-center py-24">
 			<div class="mb-8 text-center">
-				<a href="/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
+				<a href="https://synch.run/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
 				<h1 class="text-2xl text-zinc-200 tracking-tight mb-2" data-i18n="title">Welcome back</h1>
 				<p class="text-zinc-500 text-xs" data-i18n="subtitle">Sign in to your account to continue</p>
 			</div>

--- a/apps/api/public/signup.html
+++ b/apps/api/public/signup.html
@@ -16,7 +16,7 @@
 	<body class="bg-[#0a0a0a] text-zinc-400 font-sans antialiased min-h-screen flex flex-col text-sm">
 		<div class="max-w-md mx-auto px-6 w-full flex-1 flex flex-col justify-center py-24">
 			<div class="mb-8 text-center">
-				<a href="/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
+				<a href="https://synch.run/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity inline-block mb-8">Synch</a>
 				<h1 class="text-2xl text-zinc-200 tracking-tight mb-2" data-i18n="title">Create an account</h1>
 				<p class="text-zinc-500 text-xs" data-i18n="subtitle">Your vault stays end-to-end encrypted. This account only coordinates sync.</p>
 			</div>

--- a/apps/api/public/vaults.html
+++ b/apps/api/public/vaults.html
@@ -19,7 +19,7 @@
 	<body class="bg-[#0a0a0a] text-zinc-400 font-sans antialiased min-h-screen flex flex-col text-sm">
 		<div class="max-w-4xl mx-auto px-6 w-full flex-1 flex flex-col py-12">
 			<div class="flex items-center mb-8">
-				<a href="/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity">Synch</a>
+				<a href="https://synch.run/" class="text-zinc-200 font-normal tracking-wider text-xs uppercase hover:opacity-80 transition-opacity">Synch</a>
 			</div>
 			
 			<header class="flex flex-col sm:flex-row sm:items-start justify-between gap-6 mb-8">

--- a/apps/api/src/public-pages.test.ts
+++ b/apps/api/src/public-pages.test.ts
@@ -1,0 +1,14 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const apiPublicPages = ["device.html", "signin.html", "signup.html", "vaults.html"] as const;
+
+describe("API public pages", () => {
+	it.each(apiPublicPages)("links the Synch logo on %s to the marketing site", async (page) => {
+		const html = await readFile(new URL(`../public/${page}`, import.meta.url).pathname, "utf8");
+
+		expect(html).toContain('<a href="https://synch.run/"');
+		expect(html).not.toContain('<a href="/"');
+	});
+});


### PR DESCRIPTION
## Summary
- Point Synch logo links on API-hosted public pages to https://synch.run/ instead of the API origin
- Add a unit test covering the public-page logo hrefs

## Tests
- pnpm -C apps/api typecheck
- pnpm -C apps/api test:unit