### PR TITLE
Skip manifest entries the server tries to roll back

### DIFF
--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -5,3 +5,5 @@
 ## Changed
 
 ## Fixed
+
+- Prevented outdated remote file versions from overwriting newer local versions during sync.

--- a/apps/obsidian-plugin/src/i18n.ts
+++ b/apps/obsidian-plugin/src/i18n.ts
@@ -142,6 +142,7 @@ const en = {
     "sync.fileSizeBlocked": ({ count }: { count: number }) => `${count} ${count === 1 ? "file exceeds" : "files exceed"} the sync size limit.`,
     "sync.label": "Sync",
     "sync.pathCollision": ({ path }: { path: string }) => `Sync path collision detected. The remote file was saved to "${path}".`,
+    "sync.rollbackDetected": ({ path }: { path: string }) => `Sync server sent an outdated version of "${path}". It was ignored to avoid overwriting newer changes.`,
     "sync.paused": "Sync paused",
     "sync.start": "Start sync",
     "sync.state.attention_needed": "attention needed",

--- a/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/rollback-protection.test.ts
+++ b/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/rollback-protection.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "vitest";
+
+import { SyncPullService } from "../../pull-service";
+import { createInitializedTestSyncStore, createTestPlugin } from "../../../../test-support/test-plugin";
+import {
+  createCommit,
+  createPullClient,
+  createRealtimeSession,
+  createToken,
+  createVaultAdapter,
+  encryptRemoteMetadata,
+  encryptTestBlob,
+  hashText,
+  ignoreProgress,
+  TEST_VAULT_KEY,
+} from "./helpers";
+
+/**
+ * A malicious or compromised sync server can replay an old, genuinely
+ * encrypted-and-authenticated manifest entry - the AEAD proves the ciphertext
+ * was produced for that (entryId, revision, op, blobId) tuple, but proves
+ * nothing about whether it's current. The client is the only party that can
+ * catch this, since the check has to hold even when the server itself is the
+ * one lying.
+ */
+describe("SyncPullService rollback protection", () => {
+  it("rejects a manifest entry whose revision is older than what's already known locally", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = "Folder/note.md";
+    const currentBody = "current, newer content";
+    const staleBody = "stale content from an old revision";
+    const currentHash = await hashText(currentBody);
+    const staleHash = await hashText(staleBody);
+
+    // The client already fully synced this entry at revision 5.
+    await store.setCursor(4);
+    await store.upsertEntry({
+      entryId: "entry-1",
+      path,
+      revision: 5,
+      blobId: "blob-current",
+      hash: currentHash,
+      deleted: false,
+      updatedAt: 1,
+    });
+
+    const adapter = createVaultAdapter({ [path]: currentBody });
+
+    // The server replays an old, validly-encrypted revision 2 for the same entry.
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 5,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 5,
+              entryId: "entry-1",
+              revision: 2,
+              blobId: "blob-stale",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-1",
+                revision: 2,
+                blobId: "blob-stale",
+                path,
+                hash: staleHash,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const client = createPullClient({
+      blobs: {
+        "blob-stale": await encryptTestBlob("blob-stale", new TextEncoder().encode(staleBody)),
+      },
+    });
+
+    const rollbacks: Array<{ entryId: string; localRevision: number; remoteRevision: number }> = [];
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      vaultAdapter: adapter,
+      pullClient: client,
+      onProgress: ignoreProgress,
+      onRollbackDetected(event) {
+        rollbacks.push({
+          entryId: event.entryId,
+          localRevision: event.localRevision,
+          remoteRevision: event.remoteRevision,
+        });
+      },
+    });
+
+    await service.pullOnce(session);
+
+    expect(rollbacks).toEqual([
+      { entryId: "entry-1", localRevision: 5, remoteRevision: 2 },
+    ]);
+    // The vault file must never have been touched with the stale content.
+    expect(adapter.writes).not.toContain(path);
+    expect(adapter.text(path)).toBe(currentBody);
+    // The store's own record of the entry must stay at the newer revision.
+    const stored = await store.getEntryById("entry-1");
+    expect(stored?.revision).toBe(5);
+    expect(stored?.hash).toBe(currentHash);
+  });
+
+  it("still applies a manifest entry whose revision matches or exceeds what's known locally", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = "Folder/note.md";
+    const newerBody = "genuinely newer content";
+    const newerHash = await hashText(newerBody);
+
+    await store.setCursor(4);
+    await store.upsertEntry({
+      entryId: "entry-1",
+      path,
+      revision: 5,
+      blobId: "blob-current",
+      hash: await hashText("current content"),
+      deleted: false,
+      updatedAt: 1,
+    });
+
+    const adapter = createVaultAdapter({ [path]: "current content" });
+
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 6,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 6,
+              entryId: "entry-1",
+              revision: 6,
+              blobId: "blob-newer",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-1",
+                revision: 6,
+                blobId: "blob-newer",
+                path,
+                hash: newerHash,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const client = createPullClient({
+      blobs: {
+        "blob-newer": await encryptTestBlob("blob-newer", new TextEncoder().encode(newerBody)),
+      },
+    });
+
+    const rollbacks: unknown[] = [];
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      vaultAdapter: adapter,
+      pullClient: client,
+      onProgress: ignoreProgress,
+      onRollbackDetected: (event) => rollbacks.push(event),
+    });
+
+    await service.pullOnce(session);
+
+    expect(rollbacks).toEqual([]);
+    expect(adapter.text(path)).toBe(newerBody);
+    const stored = await store.getEntryById("entry-1");
+    expect(stored?.revision).toBe(6);
+  });
+
+  it("still applies a manifest entry whose revision exactly matches what's known locally (idempotent redelivery)", async () => {
+    // A reconnect/full resync can legitimately re-send the entry's current
+    // revision verbatim. The rollback check uses `<`, not `<=`, specifically
+    // so this case still applies rather than being treated as a rollback.
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = "Folder/note.md";
+    const currentBody = "current content";
+    const currentHash = await hashText(currentBody);
+
+    await store.setCursor(4);
+    await store.upsertEntry({
+      entryId: "entry-1",
+      path,
+      revision: 5,
+      blobId: "blob-current",
+      hash: currentHash,
+      deleted: false,
+      updatedAt: 1,
+    });
+
+    const adapter = createVaultAdapter({ [path]: currentBody });
+
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 5,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 5,
+              entryId: "entry-1",
+              revision: 5,
+              blobId: "blob-current",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-1",
+                revision: 5,
+                blobId: "blob-current",
+                path,
+                hash: currentHash,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const client = createPullClient({
+      blobs: {
+        "blob-current": await encryptTestBlob("blob-current", new TextEncoder().encode(currentBody)),
+      },
+    });
+
+    const rollbacks: unknown[] = [];
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      vaultAdapter: adapter,
+      pullClient: client,
+      onProgress: ignoreProgress,
+      onRollbackDetected: (event) => rollbacks.push(event),
+    });
+
+    await service.pullOnce(session);
+
+    expect(rollbacks).toEqual([]);
+    const stored = await store.getEntryById("entry-1");
+    expect(stored?.revision).toBe(5);
+  });
+});

--- a/apps/obsidian-plugin/src/sync/engine/pull-entry-state-applier.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-entry-state-applier.ts
@@ -31,6 +31,7 @@ import {
   pathsToRemoveForPlan,
   type PullConflictEvent,
   type PullEntryStateManifestItem,
+  type PullRollbackEvent,
   type PlannedEntryState,
   type PreparedEntryBlob,
   type PreparedManifestApplication,
@@ -51,6 +52,7 @@ export interface PullEntryStateApplierDeps {
   prepareConcurrency?: number;
   onProgress?: (progress: SyncProgressCounts) => Promise<void>;
   onConflict?: (event: PullConflictEvent) => void;
+  onRollbackDetected?: (event: PullRollbackEvent) => void;
   now?: () => number;
 }
 
@@ -61,7 +63,7 @@ export interface PullEntryStateApplyResult {
   conflictsCreated: number;
 }
 
-export type { PullConflictEvent, PullEntryStateManifestItem };
+export type { PullConflictEvent, PullEntryStateManifestItem, PullRollbackEvent };
 
 export interface PullEntryStateVaultAdapter
   extends ConflictFileWriter,

--- a/apps/obsidian-plugin/src/sync/engine/pull-entry-state-internal.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-entry-state-internal.ts
@@ -17,6 +17,14 @@ export interface PullConflictEvent {
   conflictPath: string | null;
 }
 
+/** A manifest item whose revision is older than what's already known locally - see the check in `PullManifestPlanner`. */
+export interface PullRollbackEvent {
+  entryId: string;
+  path: string | null;
+  localRevision: number;
+  remoteRevision: number;
+}
+
 export type PullEntryStateManifestItem = {
   state: RemoteEntryState;
   metadata: SyncedEntryMetadata;

--- a/apps/obsidian-plugin/src/sync/engine/pull-manifest-planner.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-manifest-planner.ts
@@ -19,12 +19,14 @@ import {
   type PlannedEntryState,
   type PullConflictEvent,
   type PullEntryStateManifestItem,
+  type PullRollbackEvent,
 } from "./pull-entry-state-internal";
 
 interface PullManifestPlannerDeps {
   getRemoteVaultKey: () => Uint8Array;
   vaultAdapter: ConflictFileWriter;
   onConflict?: (event: PullConflictEvent) => void;
+  onRollbackDetected?: (event: PullRollbackEvent) => void;
   now?: () => number;
 }
 
@@ -103,6 +105,24 @@ export class PullManifestPlanner {
       }
 
       const existing = await store.getEntryById(state.entryId);
+      // A well-behaved server only ever hands out strictly increasing
+      // revisions for a given entry - every legitimate mutation, delete, or
+      // restore bumps it. The AEAD binds (entryId, revision, op, blobId), so
+      // a stale-but-genuine ciphertext decrypts cleanly; nothing in the
+      // crypto layer signals that it's *old*. A malicious or compromised
+      // server can replay one verbatim and have it accepted as current
+      // unless something checks recency here - so skip (not defer: this
+      // isn't a legitimate item to retry later) rather than apply it.
+      if (existing && existing.revision > 0 && state.revision < existing.revision) {
+        this.deps.onRollbackDetected?.({
+          entryId: state.entryId,
+          path: metadata.path,
+          localRevision: existing.revision,
+          remoteRevision: state.revision,
+        });
+        continue;
+      }
+
       let finalPath: string | null = null;
       let hash: string | null = null;
       let pathConflict: PullConflictEvent | null = null;

--- a/apps/obsidian-plugin/src/sync/engine/pull-service.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-service.ts
@@ -13,6 +13,7 @@ import {
   type PullEntryStateStore,
   type PullEntryStateManifestItem,
   type PullEntryStateVaultAdapter,
+  type PullRollbackEvent,
 } from "./pull-entry-state-applier";
 
 const DEFAULT_PULL_BATCH = 50;
@@ -32,6 +33,7 @@ export interface SyncPullServiceDeps {
   applyWindowSize?: number;
   onProgress: (progress: SyncProgressCounts) => Promise<void>;
   onConflict?: (event: PullConflictEvent) => void;
+  onRollbackDetected?: (event: PullRollbackEvent) => void;
   now?: () => number;
 }
 
@@ -67,6 +69,7 @@ export class SyncPullService {
         await this.deps.onProgress(progress);
       },
       onConflict: this.deps.onConflict,
+      onRollbackDetected: this.deps.onRollbackDetected,
       now: this.deps.now,
     });
   }

--- a/apps/obsidian-plugin/src/sync/runtime/controller.ts
+++ b/apps/obsidian-plugin/src/sync/runtime/controller.ts
@@ -82,6 +82,7 @@ export class SyncController {
     notify: (message, timeout) => this.notify(message, timeout),
     notifyError: (error, prefix) => this.deps.notifyError(error, prefix),
     notifySyncConflict: (event) => this.notifySyncConflict(event),
+    notifyRollbackDetected: (event) => this.notifyRollbackDetected(event),
     setSyncProgress: (progress) => this.setSyncProgress(progress),
     setSyncStatus: (status) => this.setSyncStatus(status),
     setStorageStatus: (status) => this.setStorageStatus(status),
@@ -476,6 +477,25 @@ export class SyncController {
 
     this.notify(
       t("sync.conflictRemoteKept", { path: event.originalPath }),
+    );
+  }
+
+  private notifyRollbackDetected(event: {
+    entryId: string;
+    path: string | null;
+    localRevision: number;
+    remoteRevision: number;
+  }): void {
+    // Always logged, regardless of whether a Notice is shown - this is the
+    // durable record that the server sent a stale revision, which shouldn't
+    // happen under normal operation (see the check in PullManifestPlanner).
+    console.warn(
+      `[synch] rejected a rollback attempt for entry ${event.entryId}` +
+        (event.path ? ` (${event.path})` : "") +
+        `: server sent revision ${event.remoteRevision}, already had ${event.localRevision}`,
+    );
+    this.notify(
+      t("sync.rollbackDetected", { path: event.path ?? event.entryId }),
     );
   }
 

--- a/apps/obsidian-plugin/src/sync/runtime/engine.ts
+++ b/apps/obsidian-plugin/src/sync/runtime/engine.ts
@@ -88,6 +88,12 @@ export interface SyncEngineDeps {
     originalPath: string;
     conflictPath: string | null;
   }) => void;
+  notifyRollbackDetected: (event: {
+    entryId: string;
+    path: string | null;
+    localRevision: number;
+    remoteRevision: number;
+  }) => void;
   setSyncProgress: (progress: UserVisibleSyncProgress | null) => void;
   setSyncStatus: (status: UserVisibleSyncState) => void;
   setStorageStatus: (status: SyncStorageStatus | null) => void;
@@ -246,6 +252,7 @@ export class SyncEngine {
       this.reportActivityProgress(progress);
     },
     onConflict: (event) => this.deps.notifySyncConflict(event),
+    onRollbackDetected: (event) => this.deps.notifyRollbackDetected(event),
   });
   private readonly syncVersionHistoryService = new SyncVersionHistoryService({
     getApiBaseUrl: () => this.deps.getApiBaseUrl(),


### PR DESCRIPTION
## Summary
- The sync protocol's AEAD binds `(entryId, revision, op, blobId)` as AAD, which proves a manifest item is authentic but not that it's *current* - a stale-but-genuine ciphertext decrypts cleanly.
- A malicious or compromised server can replay an old, validly-encrypted revision for an entry the client already has newer, and nothing in the crypto layer signals that it's stale.
- `PullManifestPlanner` now compares each incoming revision against the locally known one and skips (not defers) any entry that would move an entryId backwards, logging it and surfacing a Notice. Uses strict `<` rather than `<=` so idempotent redelivery of the current revision (e.g. on reconnect) still applies normally.
- A skipped entry stays at its local revision until a future manifest legitimately moves it forward or a full resync reconciles it - the right tradeoff against a lying server, a no-op against an honest one.

## Test plan
- [x] New unit tests: rejects an older-revision replay, still applies newer revisions, still applies same-revision redelivery (idempotent reconnect case)
- [x] Full plugin test suite passing
- [x] `tsgo --noEmit --skipLibCheck` clean