### PR TITLE
fix(obsidian): prefer latest vault config state

### DIFF
--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -8,3 +8,5 @@
 - Clarified vault configuration sync descriptions across supported languages.
 
 ## Fixed
+
+- Vault settings now keep the latest synced version without creating extra conflict-copy files.

--- a/apps/obsidian-plugin/src/sync/core/vault-path-policy.test.ts
+++ b/apps/obsidian-plugin/src/sync/core/vault-path-policy.test.ts
@@ -6,6 +6,7 @@ import {
   decideVaultPathSync,
   isForbiddenVaultPath,
   shouldApplyRemoteVaultPath,
+  shouldUseLatestRemoteVaultConfig,
 } from "./vault-path-policy";
 
 describe("decideVaultPathSync", () => {
@@ -139,5 +140,28 @@ describe("shouldApplyRemoteVaultPath", () => {
         vaultConfigRules,
       }),
     ).toBe(true);
+  });
+});
+
+describe("shouldUseLatestRemoteVaultConfig", () => {
+  const vaultConfigRules = {
+    ...DEFAULT_VAULT_CONFIG_SYNC_RULES,
+    enabled: true,
+  };
+
+  it("uses latest-remote conflict handling only for enabled vault config paths", () => {
+    expect(
+      shouldUseLatestRemoteVaultConfig(".obsidian/graph.json", {
+        vaultConfigRules,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseLatestRemoteVaultConfig("Notes/daily.md", { vaultConfigRules }),
+    ).toBe(false);
+    expect(
+      shouldUseLatestRemoteVaultConfig(".obsidian/workspace.json", {
+        vaultConfigRules,
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/obsidian-plugin/src/sync/core/vault-path-policy.ts
+++ b/apps/obsidian-plugin/src/sync/core/vault-path-policy.ts
@@ -66,6 +66,17 @@ export function shouldApplyRemoteVaultPath(
   return true;
 }
 
+export function shouldUseLatestRemoteVaultConfig(
+  path: string,
+  rules: Pick<VaultPathPolicyRules, "vaultConfigRules">,
+): boolean {
+  return (
+    classifySyncPath(path, rules.vaultConfigRules.configDir) ===
+      "reserved-config-managed" &&
+    shouldSyncVaultConfigPath(path, rules.vaultConfigRules)
+  );
+}
+
 export function isForbiddenVaultPath(
   path: string,
   vaultConfigRules: Pick<VaultConfigSyncRules, "configDir">,

--- a/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/conflicts-paths.test.ts
+++ b/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/conflicts-paths.test.ts
@@ -23,6 +23,573 @@ import {
 const conflictTimestamp = () => new Date(2026, 3, 22, 10, 11, 12).getTime();
 
 describe("SyncPullService path conflicts", () => {
+  it("keeps only the latest remote version when vault config entries share a path", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const adapter = {
+      ...createVaultAdapter(),
+      isProtectedVaultPath: (candidate: string) =>
+        candidate.includes(".sync-conflict-"),
+    };
+    const conflicts: PullConflictSummary[] = [];
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 2,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 1,
+              entryId: "entry-old",
+              revision: 1,
+              blobId: "blob-old",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-old",
+                revision: 1,
+                blobId: "blob-old",
+                path,
+                hash: await hashText('{"version":"old"}'),
+              }),
+            }),
+            createCommit({
+              cursor: 2,
+              entryId: "entry-latest",
+              revision: 1,
+              blobId: "blob-latest",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-latest",
+                revision: 1,
+                blobId: "blob-latest",
+                path,
+                hash: await hashText('{"version":"latest"}'),
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({
+        blobs: {
+          "blob-old": await encryptTestBlob(
+            "blob-old",
+            new TextEncoder().encode('{"version":"old"}'),
+          ),
+          "blob-latest": await encryptTestBlob(
+            "blob-latest",
+            new TextEncoder().encode('{"version":"latest"}'),
+          ),
+        },
+      }),
+      onProgress: ignoreProgress,
+      onConflict: (event) => conflicts.push(event),
+      now: conflictTimestamp,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toEqual({
+      cursor: 2,
+      entriesApplied: 2,
+      filesWritten: 1,
+      filesDeleted: 0,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBe('{"version":"latest"}');
+    expect(adapter.text(".obsidian/graph.sync-conflict-20260422-101112.json")).toBeNull();
+    expect(await store.getRemoteStateById("entry-old")).toMatchObject({
+      path: null,
+      revision: 1,
+      blobId: "blob-old",
+    });
+    expect(await store.getEntryById("entry-latest")).toMatchObject({
+      path,
+      revision: 1,
+      blobId: "blob-latest",
+    });
+    expect(conflicts).toEqual([]);
+
+    await store.close();
+  });
+
+  it("keeps the live vault config owner when a previous loser is deleted", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const winnerBody = '{"version":"winner"}';
+    const winnerHash = await hashText(winnerBody);
+    const adapter = createVaultAdapter({ [path]: winnerBody });
+    await store.applyRemoteState({
+      entryId: "entry-loser",
+      path: null,
+      revision: 1,
+      blobId: "blob-loser",
+      hash: await hashText('{"version":"loser"}'),
+      deleted: false,
+      updatedAt: 1,
+    });
+    await store.upsertEntry({
+      entryId: "entry-winner",
+      path,
+      revision: 1,
+      blobId: "blob-winner",
+      hash: winnerHash,
+      deleted: false,
+      updatedAt: 2,
+    });
+    await store.markEntryDirty({
+      mutationId: "mutation-winner",
+      entryId: "entry-winner",
+      op: "upsert",
+      baseRevision: 1,
+      blobId: "blob-winner-local",
+      hash: winnerHash,
+      encryptedMetadata: await encryptPendingMetadata({
+        entryId: "entry-winner",
+        baseRevision: 1,
+        op: "upsert",
+        blobId: "blob-winner-local",
+        path,
+        hash: winnerHash,
+      }),
+      createdAt: 3,
+    });
+
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 4,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 4,
+              entryId: "entry-loser",
+              op: "delete",
+              revision: 2,
+              baseRevision: 1,
+              blobId: null,
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-loser",
+                revision: 2,
+                deleted: true,
+                blobId: null,
+                path,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({}),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toMatchObject({
+      entriesApplied: 1,
+      filesWritten: 0,
+      filesDeleted: 0,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBe(winnerBody);
+    expect(await store.getEntryById("entry-winner")).toMatchObject({
+      path,
+      deleted: false,
+    });
+    expect(await store.listDirtyEntries()).toEqual([
+      expect.objectContaining({ mutationId: "mutation-winner" }),
+    ]);
+    expect(await store.getRemoteStateById("entry-loser")).toMatchObject({
+      path,
+      revision: 2,
+      deleted: true,
+    });
+
+    await store.close();
+  });
+
+  it("keeps a live vault config upsert when another entry is deleted in the same window", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const liveBody = '{"version":"live"}';
+    const adapter = createVaultAdapter();
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 2,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 1,
+              entryId: "entry-live",
+              revision: 1,
+              blobId: "blob-live",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-live",
+                revision: 1,
+                blobId: "blob-live",
+                path,
+                hash: await hashText(liveBody),
+              }),
+            }),
+            createCommit({
+              cursor: 2,
+              entryId: "entry-deleted",
+              op: "delete",
+              revision: 2,
+              baseRevision: 1,
+              blobId: null,
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-deleted",
+                revision: 2,
+                deleted: true,
+                blobId: null,
+                path,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({
+        blobs: {
+          "blob-live": await encryptTestBlob(
+            "blob-live",
+            new TextEncoder().encode(liveBody),
+          ),
+        },
+      }),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toMatchObject({
+      entriesApplied: 2,
+      filesWritten: 1,
+      filesDeleted: 0,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBe(liveBody);
+    expect(await store.getEntryById("entry-live")).toMatchObject({
+      path,
+      deleted: false,
+    });
+    expect(await store.getRemoteStateById("entry-deleted")).toMatchObject({
+      path,
+      revision: 2,
+      deleted: true,
+    });
+
+    await store.close();
+  });
+
+  it("deletes a vault config path when its current owner is deleted", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const body = '{"version":"current"}';
+    const adapter = createVaultAdapter({ [path]: body });
+    await store.upsertEntry({
+      entryId: "entry-current",
+      path,
+      revision: 1,
+      blobId: "blob-current",
+      hash: await hashText(body),
+      deleted: false,
+      updatedAt: 1,
+    });
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 2,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 2,
+              entryId: "entry-current",
+              op: "delete",
+              revision: 2,
+              baseRevision: 1,
+              blobId: null,
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-current",
+                revision: 2,
+                deleted: true,
+                blobId: null,
+                path,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({}),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toMatchObject({
+      entriesApplied: 1,
+      filesWritten: 0,
+      filesDeleted: 1,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBeNull();
+    expect(await store.getEntryById("entry-current")).toMatchObject({
+      path,
+      revision: 2,
+      deleted: true,
+    });
+
+    await store.close();
+  });
+
+  it("removes the previous path of a superseded vault config entry", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const previousPath = ".obsidian/old-graph.json";
+    const sharedPath = ".obsidian/graph.json";
+    const previousBody = '{"version":"previous"}';
+    const supersededBody = '{"version":"superseded"}';
+    const latestBody = '{"version":"latest"}';
+    const adapter = createVaultAdapter({ [previousPath]: previousBody });
+    await store.upsertEntry({
+      entryId: "entry-superseded",
+      path: previousPath,
+      revision: 1,
+      blobId: "blob-previous",
+      hash: await hashText(previousBody),
+      deleted: false,
+      updatedAt: 1,
+    });
+
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 3,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 2,
+              entryId: "entry-superseded",
+              revision: 2,
+              blobId: "blob-superseded",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-superseded",
+                revision: 2,
+                blobId: "blob-superseded",
+                path: sharedPath,
+                hash: await hashText(supersededBody),
+              }),
+            }),
+            createCommit({
+              cursor: 3,
+              entryId: "entry-latest",
+              revision: 1,
+              blobId: "blob-latest",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-latest",
+                revision: 1,
+                blobId: "blob-latest",
+                path: sharedPath,
+                hash: await hashText(latestBody),
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({
+        blobs: {
+          "blob-latest": await encryptTestBlob(
+            "blob-latest",
+            new TextEncoder().encode(latestBody),
+          ),
+        },
+      }),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toMatchObject({
+      entriesApplied: 2,
+      filesWritten: 1,
+      filesDeleted: 1,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(previousPath)).toBeNull();
+    expect(adapter.text(sharedPath)).toBe(latestBody);
+    expect(await store.getRemoteStateById("entry-superseded")).toMatchObject({
+      path: null,
+      revision: 2,
+    });
+
+    await store.close();
+  });
+
+  it("rejects an invalid superseded vault config state", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const latestBody = '{"version":"latest"}';
+    const adapter = createVaultAdapter();
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 2,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 1,
+              entryId: "entry-invalid",
+              revision: 1,
+              blobId: null,
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-invalid",
+                revision: 1,
+                blobId: null,
+                path,
+                hash: await hashText('{"version":"invalid"}'),
+              }),
+            }),
+            createCommit({
+              cursor: 2,
+              entryId: "entry-latest",
+              revision: 1,
+              blobId: "blob-latest",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-latest",
+                revision: 1,
+                blobId: "blob-latest",
+                path,
+                hash: await hashText(latestBody),
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({}),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).rejects.toThrow(
+      "Entry state entry-invalid@1 is missing a blob.",
+    );
+    expect(adapter.text(path)).toBeNull();
+    expect(await store.getRemoteStateById("entry-invalid")).toBeNull();
+    expect(await store.getCursor()).toBe(0);
+
+    await store.close();
+  });
+
+  it("replaces an older tracked vault config path owner with the latest remote entry", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const oldBody = '{"version":"old"}';
+    const latestBody = '{"version":"latest"}';
+    const adapter = createVaultAdapter({ [path]: oldBody });
+    await store.upsertEntry({
+      entryId: "entry-old",
+      path,
+      revision: 1,
+      blobId: "blob-old",
+      hash: await hashText(oldBody),
+      deleted: false,
+      updatedAt: 1,
+    });
+
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 2,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 2,
+              entryId: "entry-latest",
+              revision: 1,
+              blobId: "blob-latest",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-latest",
+                revision: 1,
+                blobId: "blob-latest",
+                path,
+                hash: await hashText(latestBody),
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({
+        blobs: {
+          "blob-latest": await encryptTestBlob(
+            "blob-latest",
+            new TextEncoder().encode(latestBody),
+          ),
+        },
+      }),
+      onProgress: ignoreProgress,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toMatchObject({
+      entriesApplied: 1,
+      filesWritten: 1,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBe(latestBody);
+    expect(await store.getRemoteStateById("entry-old")).toMatchObject({ path: null });
+    expect(await store.getEntryById("entry-latest")).toMatchObject({ path });
+
+    await store.close();
+  });
+
   it("adopts an unpushed local entry when the same remote path has identical content", async () => {
     const plugin = createTestPlugin();
     const store = await createInitializedTestSyncStore(plugin);

--- a/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/conflicts-pending-upserts.test.ts
+++ b/apps/obsidian-plugin/src/sync/engine/__tests__/pull-service/conflicts-pending-upserts.test.ts
@@ -20,6 +20,105 @@ import {
 const conflictTimestamp = () => new Date(2026, 3, 22, 10, 11, 12).getTime();
 
 describe("SyncPullService pending upsert conflict resolution", () => {
+  it("lets the latest remote vault config replace a pending local version without a conflict copy", async () => {
+    const plugin = createTestPlugin();
+    const store = await createInitializedTestSyncStore(plugin);
+    const path = ".obsidian/graph.json";
+    const adapter = {
+      ...createVaultAdapter({
+        [path]: '{"local":true}',
+      }),
+      isProtectedVaultPath: (candidate: string) =>
+        candidate.includes(".sync-conflict-"),
+    };
+    const localHash = await hashText('{"local":true}');
+    const remoteHash = await hashText('{"remote":true}');
+    await store.upsertEntry({
+      entryId: "entry-graph",
+      path,
+      revision: 2,
+      blobId: "blob-current",
+      hash: localHash,
+      deleted: false,
+      updatedAt: 1,
+    });
+    await store.markEntryDirty({
+      mutationId: "mutation-graph",
+      entryId: "entry-graph",
+      op: "upsert",
+      baseRevision: 2,
+      blobId: "blob-local",
+      hash: localHash,
+      encryptedMetadata: await encryptPendingMetadata({
+        entryId: "entry-graph",
+        baseRevision: 2,
+        op: "upsert",
+        blobId: "blob-local",
+        path,
+        hash: localHash,
+      }),
+      createdAt: 2,
+    });
+
+    const conflicts: PullConflictSummary[] = [];
+    const session = createRealtimeSession({
+      pages: [
+        {
+          cursor: 3,
+          hasMore: false,
+          commits: [
+            createCommit({
+              cursor: 3,
+              entryId: "entry-graph",
+              revision: 3,
+              blobId: "blob-remote",
+              encryptedMetadata: await encryptRemoteMetadata({
+                entryId: "entry-graph",
+                revision: 3,
+                blobId: "blob-remote",
+                path,
+                hash: remoteHash,
+              }),
+            }),
+          ],
+        },
+      ],
+    });
+    const service = new SyncPullService({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      getRemoteVaultKey: () => TEST_VAULT_KEY,
+      shouldUseLatestRemoteVersion: (candidate) => candidate.startsWith(".obsidian/"),
+      vaultAdapter: adapter,
+      pullClient: createPullClient({
+        blobs: {
+          "blob-remote": await encryptTestBlob(
+            "blob-remote",
+            new TextEncoder().encode('{"remote":true}'),
+          ),
+        },
+      }),
+      onProgress: ignoreProgress,
+      onConflict: (event) => conflicts.push(event),
+      now: conflictTimestamp,
+    });
+
+    await expect(service.pullOnce(session)).resolves.toEqual({
+      cursor: 3,
+      entriesApplied: 1,
+      filesWritten: 1,
+      filesDeleted: 0,
+      conflictsCreated: 0,
+    });
+    expect(adapter.text(path)).toBe('{"remote":true}');
+    expect(adapter.text(".obsidian/graph.sync-conflict-20260422-101112.json")).toBeNull();
+    expect(await store.listDirtyEntries()).toEqual([]);
+    expect(conflicts).toEqual([]);
+
+    await store.close();
+  });
+
   it("clears a same-entry pending upsert when the pulled remote state has identical content", async () => {
     const plugin = createTestPlugin();
     const store = await createInitializedTestSyncStore(plugin);

--- a/apps/obsidian-plugin/src/sync/engine/pull-entry-state-applier.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-entry-state-applier.ts
@@ -49,6 +49,7 @@ export interface PullEntryStateApplierDeps {
   eventGate?: SyncEventGateLike;
   pullClient: Pick<SyncPullClient, "downloadBlob">;
   shouldApplyRemotePath?: (path: string) => boolean;
+  shouldUseLatestRemoteVersion?: (path: string) => boolean;
   prepareConcurrency?: number;
   onProgress?: (progress: SyncProgressCounts) => Promise<void>;
   onConflict?: (event: PullConflictEvent) => void;
@@ -188,7 +189,7 @@ export class PullEntryStateApplier {
     );
 
     return {
-      entriesApplied: prepared.plans.length,
+      entriesApplied: prepared.plans.length + prepared.superseded.length,
       filesWritten: prepared.pathsToWrite.length,
       filesDeleted,
       conflictsCreated: prepared.plans.reduce(
@@ -208,14 +209,19 @@ export class PullEntryStateApplier {
     manifest: PullEntryStateManifestItem[],
     options: { deferExternalPathOwners: boolean },
   ): Promise<PreparedManifestApplication> {
-    const { plans: allPlans, deferred } = await this.manifestPlanner.planManifest(
-      store,
-      manifest,
-      options,
-    );
+    const {
+      plans: allPlans,
+      deferred,
+      superseded,
+    } = await this.manifestPlanner.planManifest(store, manifest, options);
     const plans = allPlans.filter((plan) => this.shouldApplyPlanToVault(plan));
     await this.applySkippedRemoteStates(store, allPlans, plans);
     await this.markAlreadyCurrentVaultWrites(store, plans);
+    const supersededPathsToRemove = await this.findSupersededPathsToRemove(
+      store,
+      superseded,
+      plans,
+    );
     const pathsToWrite = uniqueSyncPaths(
       plans
         .filter((plan) => !plan.skipVaultWrite)
@@ -268,6 +274,8 @@ export class PullEntryStateApplier {
 
     return {
       plans,
+      superseded,
+      supersededPathsToRemove,
       pathsToWrite,
       pendingConflicts,
       batches,
@@ -378,7 +386,7 @@ export class PullEntryStateApplier {
         }
       | undefined,
   ): Promise<number> {
-    const originalEntries = await this.snapshotManifestEntries(store, prepared.plans);
+    const originalEntries = await this.snapshotManifestEntries(store, prepared);
     const originalDirtyEntries = await this.snapshotDirtyEntries(store, prepared);
     const pendingConflictsByPlan = groupPendingConflictsByPlan(prepared.pendingConflicts);
 
@@ -387,6 +395,7 @@ export class PullEntryStateApplier {
       let entriesApplied = 0;
       filesDeleted = await this.runWithSuppressedPaths(
         [
+          ...prepared.supersededPathsToRemove,
           ...prepared.batches.flatMap((batch) => batch.pathsToRemove),
           ...prepared.batches.flatMap((batch) =>
             batch.plans.flatMap((plan) => [plan.vaultMove?.from, plan.vaultMove?.to]),
@@ -395,6 +404,21 @@ export class PullEntryStateApplier {
         ],
         async () => {
           let removedTotal = 0;
+          await this.applySupersededRemoteEntries(store, prepared);
+          for (const path of prepared.supersededPathsToRemove) {
+            if (await removeVaultPathIfExists(this.deps.vaultAdapter, path)) {
+              removedTotal += 1;
+            }
+          }
+          entriesApplied += prepared.superseded.length;
+          if (prepared.superseded.length > 0) {
+            await this.deps.onProgress?.({
+              completedEntries: (progress?.completedOffset ?? 0) + entriesApplied,
+              totalEntries:
+                progress?.totalEntries ??
+                prepared.plans.length + prepared.superseded.length,
+            });
+          }
           for (const batch of prepared.batches) {
             const batchPendingConflicts = uniquePendingConflicts(
               batch.plans.flatMap((plan) => pendingConflictsByPlan.get(plan) ?? []),
@@ -451,7 +475,9 @@ export class PullEntryStateApplier {
             entriesApplied += batch.plans.length;
             await this.deps.onProgress?.({
               completedEntries: (progress?.completedOffset ?? 0) + entriesApplied,
-              totalEntries: progress?.totalEntries ?? prepared.plans.length,
+              totalEntries:
+                progress?.totalEntries ??
+                prepared.plans.length + prepared.superseded.length,
             });
           }
 
@@ -511,6 +537,66 @@ export class PullEntryStateApplier {
     }
   }
 
+  private async applySupersededRemoteEntries(
+    store: PullEntryStateStore,
+    prepared: PreparedManifestApplication,
+  ): Promise<void> {
+    const incomingByEntryId = new Map(
+      prepared.superseded.map((entry) => [entry.state.entryId, entry]),
+    );
+    const entryIds = new Set(incomingByEntryId.keys());
+    for (const plan of prepared.plans) {
+      if (plan.supersededPathOwner) {
+        entryIds.add(plan.supersededPathOwner.entryId);
+      }
+    }
+
+    for (const entryId of entryIds) {
+      const pending = await store.getDirtyEntryMutation(entryId);
+      if (pending) {
+        await store.clearDirtyEntryByMutationId(pending.mutationId);
+      }
+      await store.clearLocalState(entryId);
+
+      const incoming = incomingByEntryId.get(entryId);
+      if (incoming) {
+        await store.applyRemoteState({
+          entryId,
+          path: incoming.state.deleted ? incoming.metadata.path : null,
+          revision: incoming.state.revision,
+          blobId: incoming.state.deleted ? null : incoming.state.blobId,
+          hash: incoming.state.deleted ? null : incoming.metadata.hash,
+          deleted: incoming.state.deleted,
+          updatedAt: incoming.state.updatedAt,
+        });
+        continue;
+      }
+
+      const remote = await store.getRemoteStateById(entryId);
+      if (remote) {
+        await store.applyRemoteState({ ...remote, path: remote.deleted ? remote.path : null });
+      }
+    }
+  }
+
+  private async findSupersededPathsToRemove(
+    store: PullEntryStateStore,
+    superseded: PullEntryStateManifestItem[],
+    plans: PlannedEntryState[],
+  ): Promise<string[]> {
+    const claimedPaths = new Set(
+      plans.map((plan) => plan.finalPath).filter((path): path is string => !!path),
+    );
+    const paths: Array<string | null> = [];
+    for (const item of superseded) {
+      const existing = await store.getEntryById(item.state.entryId);
+      paths.push(
+        existing?.path && !claimedPaths.has(existing.path) ? existing.path : null,
+      );
+    }
+    return uniqueSyncPaths(paths);
+  }
+
   private async clearChangingStorePaths(
     store: PullEntryStateStore,
     plans: PlannedEntryState[],
@@ -531,14 +617,20 @@ export class PullEntryStateApplier {
 
   private async snapshotManifestEntries(
     store: PullEntryStateStore,
-    plans: PlannedEntryState[],
+    prepared: PreparedManifestApplication,
   ): Promise<Map<string, SnapshotEntryState>> {
     const entryIds = new Set<string>();
-    for (const plan of plans) {
+    for (const plan of prepared.plans) {
       entryIds.add(plan.state.entryId);
       if (plan.adoptedLocalEntry) {
         entryIds.add(plan.adoptedLocalEntry.entry.entryId);
       }
+      if (plan.supersededPathOwner) {
+        entryIds.add(plan.supersededPathOwner.entryId);
+      }
+    }
+    for (const entry of prepared.superseded) {
+      entryIds.add(entry.state.entryId);
     }
 
     const entries = new Map<string, SnapshotEntryState>();
@@ -561,6 +653,12 @@ export class PullEntryStateApplier {
       if (plan.adoptedLocalEntry) {
         entryIds.add(plan.adoptedLocalEntry.entry.entryId);
       }
+      if (plan.supersededPathOwner) {
+        entryIds.add(plan.supersededPathOwner.entryId);
+      }
+    }
+    for (const entry of prepared.superseded) {
+      entryIds.add(entry.state.entryId);
     }
     for (const pendingConflict of prepared.pendingConflicts) {
       entryIds.add(pendingConflict.pending.entryId);
@@ -577,6 +675,11 @@ export class PullEntryStateApplier {
     store: PullEntryStateStore,
     entries: ReadonlyMap<string, SnapshotEntryState>,
   ): Promise<void> {
+    for (const entryId of entries.keys()) {
+      await store.clearRemoteState(entryId);
+      await store.clearLocalState(entryId);
+    }
+
     for (const [entryId, entry] of entries) {
       if (entry.remote) {
         await store.applyRemoteState(entry.remote);

--- a/apps/obsidian-plugin/src/sync/engine/pull-entry-state-internal.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-entry-state-internal.ts
@@ -41,6 +41,7 @@ export type PlannedEntryState = {
   hash: string | null;
   pathConflict: PullConflictEvent | null;
   pendingConflict: PullConflictEvent | null;
+  supersededPathOwner: SyncEntryRow | null;
 };
 
 export type PlannedVaultMove = {
@@ -88,6 +89,8 @@ export type PreparedPathBatch = {
 
 export type PreparedManifestApplication = {
   plans: PlannedEntryState[];
+  superseded: PullEntryStateManifestItem[];
+  supersededPathsToRemove: string[];
   pathsToWrite: string[];
   pendingConflicts: PreparedPendingConflict[];
   batches: PreparedPathBatch[];
@@ -252,7 +255,9 @@ export function pathsToRemoveForPlan(
   plan: PlannedEntryState,
 ): Array<string | null | undefined> {
   if (plan.state.deleted) {
-    return [plan.existing?.path ?? plan.metadata.path];
+    // Metadata keeps the entry's historical path, which another entry may now
+    // own. Only remove a path still associated with the deleted entry itself.
+    return [plan.existing?.path];
   }
 
   if (plan.vaultMove) {

--- a/apps/obsidian-plugin/src/sync/engine/pull-manifest-planner.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-manifest-planner.ts
@@ -27,6 +27,7 @@ interface PullManifestPlannerDeps {
   vaultAdapter: ConflictFileWriter;
   onConflict?: (event: PullConflictEvent) => void;
   onRollbackDetected?: (event: PullRollbackEvent) => void;
+  shouldUseLatestRemoteVersion?: (path: string) => boolean;
   now?: () => number;
 }
 
@@ -40,19 +41,50 @@ export class PullManifestPlanner {
   ): Promise<{
     plans: PlannedEntryState[];
     deferred: PullEntryStateManifestItem[];
+    superseded: PullEntryStateManifestItem[];
   }> {
+    for (const item of manifest) {
+      this.validateManifestItem(item);
+    }
+
+    const latestManagedEntryByPath = this.findLatestManagedEntryByPath(manifest);
+    const activeManifest: PullEntryStateManifestItem[] = [];
+    const superseded: PullEntryStateManifestItem[] = [];
+    for (const item of manifest) {
+      const winnerEntryId = latestManagedEntryByPath.get(item.metadata.path);
+      if (winnerEntryId && winnerEntryId !== item.state.entryId) {
+        const existing = await store.getEntryById(item.state.entryId);
+        if (
+          existing &&
+          existing.revision > 0 &&
+          item.state.revision < existing.revision
+        ) {
+          this.deps.onRollbackDetected?.({
+            entryId: item.state.entryId,
+            path: item.metadata.path,
+            localRevision: existing.revision,
+            remoteRevision: item.state.revision,
+          });
+          continue;
+        }
+        superseded.push(item);
+        continue;
+      }
+      activeManifest.push(item);
+    }
+
     const deferredEntryIds = new Set<string>();
     if (options.deferExternalPathOwners) {
       let changed = true;
       while (changed) {
         changed = false;
         const activeEntryIds = new Set(
-          manifest
+          activeManifest
             .map((item) => item.state.entryId)
             .filter((entryId) => !deferredEntryIds.has(entryId)),
         );
 
-        for (const { state, metadata } of manifest) {
+        for (const { state, metadata } of activeManifest) {
           if (deferredEntryIds.has(state.entryId) || state.deleted) {
             continue;
           }
@@ -72,7 +104,10 @@ export class PullManifestPlanner {
             pathOwner.entryId !== state.entryId &&
             !activeEntryIds.has(pathOwner.entryId) &&
             !adoptedLocalEntry;
-          if (externalPathOwner) {
+          if (
+            externalPathOwner &&
+            !this.deps.shouldUseLatestRemoteVersion?.(metadata.path)
+          ) {
             deferredEntryIds.add(state.entryId);
             changed = true;
           }
@@ -83,13 +118,13 @@ export class PullManifestPlanner {
     const deferredCursorThreshold =
       deferredEntryIds.size > 0
         ? Math.min(
-            ...manifest
+            ...activeManifest
               .filter((item) => deferredEntryIds.has(item.state.entryId))
               .map((item) => item.state.updatedSeq),
           )
         : null;
     const deltaEntryIds = new Set(
-      manifest
+      activeManifest
         .filter((item) => !isDeferredByCursorThreshold(item, deferredCursorThreshold))
         .map((item) => item.state.entryId),
     );
@@ -97,7 +132,7 @@ export class PullManifestPlanner {
     const plans: PlannedEntryState[] = [];
     const deferred: PullEntryStateManifestItem[] = [];
 
-    for (const item of manifest) {
+    for (const item of activeManifest) {
       const { state, metadata } = item;
       if (isDeferredByCursorThreshold(item, deferredCursorThreshold)) {
         deferred.push(item);
@@ -128,6 +163,7 @@ export class PullManifestPlanner {
       let pathConflict: PullConflictEvent | null = null;
       let adoptedLocalEntry: AdoptedLocalEntry | null = null;
       let vaultMove: PlannedEntryState["vaultMove"] = null;
+      let supersededPathOwner: SyncEntryRow | null = null;
 
       if (!state.deleted) {
         if (!state.blobId) {
@@ -148,17 +184,27 @@ export class PullManifestPlanner {
           pathOwner.entryId !== state.entryId &&
           !deltaEntryIds.has(pathOwner.entryId) &&
           !adoptedLocalEntry;
-        if (externalPathOwner && options.deferExternalPathOwners) {
+        if (
+          externalPathOwner &&
+          options.deferExternalPathOwners &&
+          !this.deps.shouldUseLatestRemoteVersion?.(metadata.path)
+        ) {
           deferred.push(item);
           continue;
         }
         if (duplicateEntryId || externalPathOwner) {
-          pathConflict = await this.createPathCollisionEvent(
-            state.entryId,
-            metadata.path,
-            reservedPaths,
-          );
-          finalPath = pathConflict.conflictPath;
+          if (this.deps.shouldUseLatestRemoteVersion?.(metadata.path)) {
+            supersededPathOwner =
+              pathOwner && pathOwner.entryId !== state.entryId ? pathOwner : null;
+            finalPath = metadata.path;
+          } else {
+            pathConflict = await this.createPathCollisionEvent(
+              state.entryId,
+              metadata.path,
+              reservedPaths,
+            );
+            finalPath = pathConflict.conflictPath;
+          }
         } else {
           finalPath = metadata.path;
         }
@@ -175,8 +221,10 @@ export class PullManifestPlanner {
           adoptedLocalEntry,
         );
         reservedPaths.set(finalPath, state.entryId);
-      } else if (metadata.hash !== null) {
-        throw new Error(`Deleted entry state ${state.entryId}@${state.revision} has a hash.`);
+      } else {
+        if (metadata.hash !== null) {
+          throw new Error(`Deleted entry state ${state.entryId}@${state.revision} has a hash.`);
+        }
       }
 
       plans.push({
@@ -190,10 +238,56 @@ export class PullManifestPlanner {
         hash,
         pathConflict,
         pendingConflict: null,
+        supersededPathOwner,
       });
     }
 
-    return { plans, deferred };
+    return { plans, deferred, superseded };
+  }
+
+  private validateManifestItem(item: PullEntryStateManifestItem): void {
+    const { state, metadata } = item;
+    if (!state.deleted) {
+      if (!state.blobId) {
+        throw new Error(`Entry state ${state.entryId}@${state.revision} is missing a blob.`);
+      }
+      if (!metadata.hash) {
+        throw new Error(`Entry state ${state.entryId}@${state.revision} is missing a hash.`);
+      }
+      return;
+    }
+
+    if (metadata.hash !== null) {
+      throw new Error(`Deleted entry state ${state.entryId}@${state.revision} has a hash.`);
+    }
+  }
+
+  private findLatestManagedEntryByPath(
+    manifest: PullEntryStateManifestItem[],
+  ): Map<string, string> {
+    const latest = new Map<string, PullEntryStateManifestItem>();
+    for (const item of manifest) {
+      const path = item.metadata.path;
+      // Tombstones are scoped to their entry id. They must not defeat a live
+      // state for another entry that now owns the same managed config path.
+      if (item.state.deleted || !this.deps.shouldUseLatestRemoteVersion?.(path)) {
+        continue;
+      }
+
+      const current = latest.get(path);
+      if (
+        !current ||
+        item.state.updatedSeq > current.state.updatedSeq ||
+        (item.state.updatedSeq === current.state.updatedSeq &&
+          item.state.entryId > current.state.entryId)
+      ) {
+        latest.set(path, item);
+      }
+    }
+
+    return new Map(
+      [...latest].map(([path, item]) => [path, item.state.entryId]),
+    );
   }
 
   private async planVaultMove(

--- a/apps/obsidian-plugin/src/sync/engine/pull-pending-mutation-handler.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-pending-mutation-handler.ts
@@ -66,6 +66,16 @@ export class PullPendingMutationHandler {
       };
     }
 
+    if (this.deps.shouldUseLatestRemoteVersion?.(metadata.path)) {
+      return {
+        plan,
+        pending,
+        event: null,
+        conflictBytes: null,
+        merge: { kind: "remote" },
+      };
+    }
+
     const entryState = await store.getEntryStateById(pending.entryId);
     const merge = await this.preparePendingTextMerge(
       store,
@@ -262,7 +272,9 @@ export class PullPendingMutationHandler {
 
     const candidatePaths = new Set(
       (plan.state.deleted
-        ? [plan.metadata.path, plan.existing?.path]
+        // A tombstone must not consume another entry's pending mutation merely
+        // because its historical metadata names the same path.
+        ? [plan.existing?.path]
         : [plan.finalPath, plan.existing?.path]
       ).filter((path): path is string => !!path),
     );

--- a/apps/obsidian-plugin/src/sync/engine/pull-service.ts
+++ b/apps/obsidian-plugin/src/sync/engine/pull-service.ts
@@ -26,6 +26,7 @@ export interface SyncPullServiceDeps {
   getSyncStore: () => SyncPullStore | null;
   getRemoteVaultKey: () => Uint8Array;
   shouldApplyRemotePath?: (path: string) => boolean;
+  shouldUseLatestRemoteVersion?: (path: string) => boolean;
   vaultAdapter: PullVaultAdapter;
   eventGate?: SyncEventGateLike;
   pullClient?: Pick<SyncPullClient, "downloadBlob">;
@@ -63,6 +64,7 @@ export class SyncPullService {
       eventGate: this.deps.eventGate,
       pullClient: this.pullClient,
       shouldApplyRemotePath: this.deps.shouldApplyRemotePath,
+      shouldUseLatestRemoteVersion: this.deps.shouldUseLatestRemoteVersion,
       prepareConcurrency:
         this.deps.prepareConcurrency ?? DEFAULT_PULL_PREPARE_CONCURRENCY,
       onProgress: async (progress) => {

--- a/apps/obsidian-plugin/src/sync/runtime/engine.ts
+++ b/apps/obsidian-plugin/src/sync/runtime/engine.ts
@@ -20,6 +20,7 @@ import {
 import {
   decideVaultPathSync,
   shouldApplyRemoteVaultPath,
+  shouldUseLatestRemoteVaultConfig,
 } from "../core/vault-path-policy";
 import { decryptSyncBlob, decryptSyncMetadata } from "../core/crypto";
 import {
@@ -251,6 +252,10 @@ export class SyncEngine {
     getRemoteVaultKey: () => this.deps.getRemoteVaultKey(),
     shouldApplyRemotePath: (path) =>
       shouldApplyRemoteVaultPath(path, {
+        vaultConfigRules: this.deps.getVaultConfigSyncRules(),
+      }),
+    shouldUseLatestRemoteVersion: (path) =>
+      shouldUseLatestRemoteVaultConfig(path, {
         vaultConfigRules: this.deps.getVaultConfigSyncRules(),
       }),
     eventGate: this.syncEventGate,


### PR DESCRIPTION
## Summary
- resolve managed vault-config path collisions by keeping the latest remote entry instead of creating protected conflict-copy files
- safely update superseded entry state, pending mutations, tombstones, and path ownership while preserving existing conflict behavior for normal notes
- add regression coverage and release notes for the user-visible fix

Related to #16. Keep the issue open until the fix is verified in real-world sync usage.

## Test plan
- [x] `pnpm -C apps/obsidian-plugin test -- src/sync/core/vault-path-policy.test.ts src/sync/engine/__tests__/pull-service/conflicts-paths.test.ts src/sync/engine/__tests__/pull-service/conflicts-pending-upserts.test.ts`
- [x] `pnpm -C apps/obsidian-plugin typecheck`