### PR TITLE
fix(api): pin Better Auth schema versions

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -59,14 +59,14 @@
 		"wrangler": "^4.82.2"
 	},
 	"dependencies": {
-		"@better-auth/drizzle-adapter": "^1.6.2",
+		"@better-auth/drizzle-adapter": "1.6.2",
 		"@hono/node-server": "^2.0.12",
 		"@hono/zod-validator": "^0.7.6",
 		"@libsql/client": "^0.15.15",
-		"@polar-sh/better-auth": "^1.8.3",
+		"@polar-sh/better-auth": "1.8.3",
 		"@polar-sh/sdk": "^0.46.7",
 		"aws4fetch": "^1.0.20",
-		"better-auth": "^1.6.2",
+		"better-auth": "1.6.2",
 		"better-sqlite3": "^12.4.1",
 		"drizzle-orm": "^0.45.2",
 		"hono": "^4.12.14",

--- a/apps/api/pnpm-lock.yaml
+++ b/apps/api/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@better-auth/drizzle-adapter':
-        specifier: ^1.6.2
+        specifier: 1.6.2
         version: 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))
       '@hono/node-server':
         specifier: ^2.0.12
@@ -21,7 +21,7 @@ importers:
         specifier: ^0.15.15
         version: 0.15.15
       '@polar-sh/better-auth':
-        specifier: ^1.8.3
+        specifier: 1.8.3
         version: 1.8.3(@polar-sh/sdk@0.46.7)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@stripe/stripe-js@7.9.0)(better-auth@1.6.2(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1)(zod@4.3.6)
       '@polar-sh/sdk':
         specifier: ^0.46.7
@@ -30,7 +30,7 @@ importers:
         specifier: ^1.0.20
         version: 1.0.20
       better-auth:
-        specifier: ^1.6.2
+        specifier: 1.6.2
         version: 1.6.2(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-sqlite3:
         specifier: ^12.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   apps/api:
     dependencies:
       '@better-auth/drizzle-adapter':
-        specifier: ^1.6.2
+        specifier: 1.6.2
         version: 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.16)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))
       '@hono/node-server':
         specifier: ^2.0.12
@@ -30,7 +30,7 @@ importers:
         specifier: ^0.15.15
         version: 0.15.15
       '@polar-sh/better-auth':
-        specifier: ^1.8.3
+        specifier: 1.8.3
         version: 1.8.3(@polar-sh/sdk@0.46.7)(@stripe/react-stripe-js@4.0.2(@stripe/stripe-js@7.9.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(@stripe/stripe-js@7.9.0)(better-auth@1.6.2(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3))))(react-dom@19.2.5(react@19.2.5))(react-is@19.2.5)(react@19.2.5)(redux@5.0.1)(zod@4.3.6)
       '@polar-sh/sdk':
         specifier: ^0.46.7
@@ -39,7 +39,7 @@ importers:
         specifier: ^1.0.20
         version: 1.0.20
       better-auth:
-        specifier: ^1.6.2
+        specifier: 1.6.2
         version: 1.6.2(@cloudflare/workers-types@5.20260727.1)(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@5.20260727.1)(@libsql/client@0.15.15)(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/pg@8.20.0)(@types/sql.js@1.4.11)(better-sqlite3@12.11.1)(kysely@0.28.16)(sql.js@1.14.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(vite@8.1.5(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)))
       better-sqlite3:
         specifier: ^12.4.1


### PR DESCRIPTION
### Problem
Standalone Cloudflare deployments can resolve the `^1.6.2` Better Auth dependencies to `1.7.1`. That version expects an `issuer` field in the Drizzle `account` schema, while Synch’s checked-in schema targets Better Auth `1.6.2`.
During email signup, the user row is committed before credential creation fails with:
`The field "issuer" does not exist in the "account" Drizzle schema.`
This leaves an orphaned user: subsequent signup reports that the email exists, while login fails because no password account was created.

### Fix
- Pin `better-auth` and `@better-auth/drizzle-adapter` to `1.6.2`.
- Pin the related Polar integration to its tested `1.8.3` version.
- Synchronize the workspace and standalone API lockfiles.
Auth dependency upgrades that require schema changes must now be made deliberately alongside the corresponding migration.

### Verification
- `pnpm check:api-lockfile`
- TypeScript check
- Cloudflare auth integration tests: 5 passed
- Verified against a real Cloudflare D1 deployment: signup and login succeed