### PR TITLE
fix(obsidian): scope stored secrets per vault

### DIFF
--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -13,4 +13,5 @@
 
 ## Fixed
 
+- Store vault credentials separately for each Obsidian vault and automatically migrate existing credentials to vault-scoped storage.
 - Show a clear “more storage is needed” state in the status bar and sync settings after a vault reaches its storage quota.

--- a/apps/obsidian-plugin/src/adapters/auth-session-storage.ts
+++ b/apps/obsidian-plugin/src/adapters/auth-session-storage.ts
@@ -1,24 +1,71 @@
 import type { Plugin } from "obsidian";
 
 import type { AuthSessionTokenStore } from "@synch/sync-client/auth/session-token-store";
+import { getOrCreateSecretScopeId } from "./secret-scope";
 
-const SESSION_TOKEN_SECRET = "synch-session-token";
+const LEGACY_SESSION_TOKEN_SECRET = "synch-session-token";
+
+function sessionTokenSecretName(secretScopeId: string): string {
+  return `${LEGACY_SESSION_TOKEN_SECRET}-${secretScopeId}`;
+}
+
+export async function migrateLegacyAuthSessionToken(plugin: Plugin): Promise<void> {
+  try {
+    const secretScopeId = getOrCreateSecretScopeId(plugin);
+    const scopedSecretName = sessionTokenSecretName(secretScopeId);
+    const scopedToken =
+      plugin.app.secretStorage.getSecret(scopedSecretName)?.trim() ?? "";
+    if (scopedToken) {
+      plugin.app.secretStorage.setSecret(LEGACY_SESSION_TOKEN_SECRET, "");
+      return;
+    }
+
+    const legacyToken =
+      plugin.app.secretStorage.getSecret(LEGACY_SESSION_TOKEN_SECRET)?.trim() ?? "";
+    if (!legacyToken) {
+      return;
+    }
+
+    plugin.app.secretStorage.setSecret(scopedSecretName, legacyToken);
+    plugin.app.secretStorage.setSecret(LEGACY_SESSION_TOKEN_SECRET, "");
+  } catch {
+    // Leave the legacy secret untouched if copying fails so the next plugin
+    // start can retry without turning the storage error into sign-out.
+  }
+}
 
 export class ObsidianAuthSessionTokenStore implements AuthSessionTokenStore {
   constructor(private readonly plugin: Plugin) {}
 
   async read(): Promise<string> {
-    return (
-      this.plugin.app.secretStorage.getSecret(SESSION_TOKEN_SECRET)?.trim() ?? ""
-    );
+    try {
+      const secretScopeId = getOrCreateSecretScopeId(this.plugin);
+      return (
+        this.plugin.app.secretStorage
+          .getSecret(sessionTokenSecretName(secretScopeId))
+          ?.trim() ?? ""
+      );
+    } catch {
+      return "";
+    }
   }
 
   async write(token: string): Promise<void> {
-    this.plugin.app.secretStorage.setSecret(SESSION_TOKEN_SECRET, token.trim());
+    const secretScopeId = getOrCreateSecretScopeId(this.plugin);
+    this.plugin.app.secretStorage.setSecret(
+      sessionTokenSecretName(secretScopeId),
+      token.trim(),
+    );
+    this.plugin.app.secretStorage.setSecret(LEGACY_SESSION_TOKEN_SECRET, "");
   }
 
   async clear(): Promise<void> {
-    this.plugin.app.secretStorage.setSecret(SESSION_TOKEN_SECRET, "");
+    const secretScopeId = getOrCreateSecretScopeId(this.plugin);
+    this.plugin.app.secretStorage.setSecret(
+      sessionTokenSecretName(secretScopeId),
+      "",
+    );
+    this.plugin.app.secretStorage.setSecret(LEGACY_SESSION_TOKEN_SECRET, "");
   }
 }
 

--- a/apps/obsidian-plugin/src/adapters/remote-vault-device-storage.ts
+++ b/apps/obsidian-plugin/src/adapters/remote-vault-device-storage.ts
@@ -2,16 +2,80 @@ import type { Plugin } from "obsidian";
 
 import { decodeBase64, encodeBase64 } from "@synch/vault-crypto";
 import type { StoredRemoteVaultKeySecret } from "@synch/sync-client/remote-vault/types";
+import { getOrCreateSecretScopeId } from "./secret-scope";
 
 export type { StoredRemoteVaultKeySecret };
 
-const REMOTE_VAULT_KEY_SECRET = "synch-remote-vault-key";
+const LEGACY_REMOTE_VAULT_KEY_SECRET = "synch-remote-vault-key";
+
+function remoteVaultKeySecretName(secretScopeId: string): string {
+  return `${LEGACY_REMOTE_VAULT_KEY_SECRET}-${secretScopeId}`;
+}
+
+export async function migrateLegacyRemoteVaultKeySecret(
+  plugin: Plugin,
+): Promise<void> {
+  try {
+    const secretScopeId = getOrCreateSecretScopeId(plugin);
+    const scopedSecretName = remoteVaultKeySecretName(secretScopeId);
+    const scopedRaw = plugin.app.secretStorage.getSecret(scopedSecretName)?.trim() ?? "";
+    if (decodeStoredRemoteVaultKey(scopedRaw)) {
+      plugin.app.secretStorage.setSecret(LEGACY_REMOTE_VAULT_KEY_SECRET, "");
+      return;
+    }
+
+    const legacyRaw =
+      plugin.app.secretStorage.getSecret(LEGACY_REMOTE_VAULT_KEY_SECRET)?.trim() ?? "";
+    const legacySecret = decodeStoredRemoteVaultKey(legacyRaw);
+    if (!legacySecret) {
+      return;
+    }
+
+    plugin.app.secretStorage.setSecret(
+      scopedSecretName,
+      encodeBase64(legacySecret.remoteVaultKey),
+    );
+    plugin.app.secretStorage.setSecret(LEGACY_REMOTE_VAULT_KEY_SECRET, "");
+  } catch {
+    // Leave the legacy secret untouched if copying fails so the next plugin
+    // start can retry without losing the existing vault key.
+  }
+}
 
 export async function readStoredRemoteVaultKeySecret(
   plugin: Plugin,
 ): Promise<StoredRemoteVaultKeySecret | null> {
-  const raw =
-    plugin.app.secretStorage.getSecret(REMOTE_VAULT_KEY_SECRET)?.trim() ?? "";
+  try {
+    const secretScopeId = getOrCreateSecretScopeId(plugin);
+    const scopedSecretName = remoteVaultKeySecretName(secretScopeId);
+    const scopedRaw = plugin.app.secretStorage.getSecret(scopedSecretName)?.trim() ?? "";
+    return decodeStoredRemoteVaultKey(scopedRaw);
+  } catch {
+    return null;
+  }
+}
+
+export async function writeStoredRemoteVaultKeySecret(
+  plugin: Plugin,
+  secret: StoredRemoteVaultKeySecret,
+): Promise<void> {
+  const secretScopeId = getOrCreateSecretScopeId(plugin);
+  plugin.app.secretStorage.setSecret(
+    remoteVaultKeySecretName(secretScopeId),
+    encodeBase64(secret.remoteVaultKey),
+  );
+  plugin.app.secretStorage.setSecret(LEGACY_REMOTE_VAULT_KEY_SECRET, "");
+}
+
+export async function clearStoredRemoteVaultKeySecret(plugin: Plugin): Promise<void> {
+  const secretScopeId = getOrCreateSecretScopeId(plugin);
+  plugin.app.secretStorage.setSecret(remoteVaultKeySecretName(secretScopeId), "");
+  plugin.app.secretStorage.setSecret(LEGACY_REMOTE_VAULT_KEY_SECRET, "");
+}
+
+function decodeStoredRemoteVaultKey(
+  raw: string,
+): StoredRemoteVaultKeySecret | null {
   if (!raw) {
     return null;
   }
@@ -23,18 +87,4 @@ export async function readStoredRemoteVaultKeySecret(
   } catch {
     return null;
   }
-}
-
-export async function writeStoredRemoteVaultKeySecret(
-  plugin: Plugin,
-  secret: StoredRemoteVaultKeySecret,
-): Promise<void> {
-  plugin.app.secretStorage.setSecret(
-    REMOTE_VAULT_KEY_SECRET,
-    encodeBase64(secret.remoteVaultKey),
-  );
-}
-
-export async function clearStoredRemoteVaultKeySecret(plugin: Plugin): Promise<void> {
-  plugin.app.secretStorage.setSecret(REMOTE_VAULT_KEY_SECRET, "");
 }

--- a/apps/obsidian-plugin/src/adapters/secret-scope.ts
+++ b/apps/obsidian-plugin/src/adapters/secret-scope.ts
@@ -1,0 +1,28 @@
+import type { Plugin } from "obsidian";
+
+const SECRET_SCOPE_ID_KEY = "synch.secretScopeId";
+
+/**
+ * Secret storage needs an identity that survives sync-store resets. The sync
+ * local vault ID is intentionally cleared when local sync state is reset, so
+ * it must not be used as the secret namespace.
+ */
+export function getOrCreateSecretScopeId(plugin: Plugin): string {
+  const existing = readSecretScopeId(plugin);
+  if (existing) {
+    return existing;
+  }
+
+  const created = crypto.randomUUID();
+  plugin.app.saveLocalStorage(SECRET_SCOPE_ID_KEY, created);
+  return created;
+}
+
+function readSecretScopeId(plugin: Plugin): string {
+  return readString(plugin, SECRET_SCOPE_ID_KEY);
+}
+
+function readString(plugin: Plugin, key: string): string {
+  const value = plugin.app.loadLocalStorage(key) as unknown;
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/apps/obsidian-plugin/src/adapters/secret-storage.test.ts
+++ b/apps/obsidian-plugin/src/adapters/secret-storage.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+
+import type { Plugin } from "obsidian";
+
+import { encodeBase64 } from "@synch/vault-crypto";
+import {
+  clearAuthSessionToken,
+  migrateLegacyAuthSessionToken,
+  ObsidianAuthSessionTokenStore,
+} from "./auth-session-storage";
+import { clearLocalVaultId } from "./dexie-store/local-vault";
+import {
+  clearStoredRemoteVaultKeySecret,
+  migrateLegacyRemoteVaultKeySecret,
+  readStoredRemoteVaultKeySecret,
+  writeStoredRemoteVaultKeySecret,
+} from "./remote-vault-device-storage";
+import { getOrCreateSecretScopeId } from "./secret-scope";
+import { SynchPluginSessionStore } from "../app/session-store";
+import { Plugin as TestPluginClass } from "../test-stubs/obsidian";
+
+const TestPlugin = TestPluginClass as unknown as new () => Plugin;
+
+describe("vault-scoped secret storage", () => {
+  it("stores remote vault keys separately for each vault", async () => {
+    const pluginA = createPlugin("scope-a");
+    const pluginB = createPlugin("scope-b");
+    const keyA = new Uint8Array([1, 2, 3]);
+    const keyB = new Uint8Array([4, 5, 6]);
+    pluginA.app.secretStorage.setSecret(
+      "synch-remote-vault-key",
+      encodeBase64(new Uint8Array([9, 8, 7])),
+    );
+
+    await writeStoredRemoteVaultKeySecret(pluginA, { remoteVaultKey: keyA });
+    await writeStoredRemoteVaultKeySecret(pluginB, { remoteVaultKey: keyB });
+
+    expect(
+      pluginA.app.secretStorage.getSecret("synch-remote-vault-key-scope-a"),
+    ).toBe(encodeBase64(keyA));
+    expect(
+      pluginB.app.secretStorage.getSecret("synch-remote-vault-key-scope-b"),
+    ).toBe(encodeBase64(keyB));
+    expect(pluginA.app.secretStorage.getSecret("synch-remote-vault-key")).toBe(
+      "",
+    );
+    await expect(readStoredRemoteVaultKeySecret(pluginA)).resolves.toEqual({
+      remoteVaultKey: keyA,
+    });
+    await expect(readStoredRemoteVaultKeySecret(pluginB)).resolves.toEqual({
+      remoteVaultKey: keyB,
+    });
+  });
+
+  it("only reads the scoped remote vault key after startup migration", async () => {
+    const plugin = createPlugin("scope-a");
+    const key = new Uint8Array([1, 2, 3]);
+    const encodedKey = encodeBase64(key);
+    plugin.app.secretStorage.setSecret("synch-remote-vault-key", encodedKey);
+
+    await expect(readStoredRemoteVaultKeySecret(plugin)).resolves.toBeNull();
+    expect(
+      plugin.app.secretStorage.getSecret("synch-remote-vault-key-scope-a"),
+    ).toBeUndefined();
+
+    await migrateLegacyRemoteVaultKeySecret(plugin);
+    await expect(readStoredRemoteVaultKeySecret(plugin)).resolves.toEqual({
+      remoteVaultKey: key,
+    });
+    expect(
+      plugin.app.secretStorage.getSecret("synch-remote-vault-key-scope-a"),
+    ).toBe(encodedKey);
+    expect(plugin.app.secretStorage.getSecret("synch-remote-vault-key")).toBe(
+      "",
+    );
+  });
+
+  it("does not resurrect a cleared remote key from the legacy slot", async () => {
+    const plugin = createPlugin("scope-a");
+    const key = new Uint8Array([1, 2, 3]);
+    const encodedKey = encodeBase64(key);
+    plugin.app.secretStorage.setSecret("synch-remote-vault-key", encodedKey);
+
+    await migrateLegacyRemoteVaultKeySecret(plugin);
+    await clearStoredRemoteVaultKeySecret(plugin);
+
+    await migrateLegacyRemoteVaultKeySecret(plugin);
+    await expect(readStoredRemoteVaultKeySecret(plugin)).resolves.toBeNull();
+    expect(plugin.app.secretStorage.getSecret("synch-remote-vault-key")).toBe("");
+  });
+
+  it("migrates the legacy remote key without a stored sync connection", async () => {
+    const plugin = createPlugin("scope-a");
+    const key = new Uint8Array([1, 2, 3]);
+    plugin.app.secretStorage.setSecret(
+      "synch-remote-vault-key",
+      encodeBase64(key),
+    );
+
+    await migrateLegacyRemoteVaultKeySecret(plugin);
+
+    expect(await readStoredRemoteVaultKeySecret(plugin)).toEqual({
+      remoteVaultKey: key,
+    });
+  });
+
+  it("migrates both legacy credentials during startup migration", async () => {
+    const plugin = createPlugin("scope-a");
+    const key = new Uint8Array([1, 2, 3]);
+    plugin.app.secretStorage.setSecret("synch-session-token", "legacy-token");
+    plugin.app.secretStorage.setSecret(
+      "synch-remote-vault-key",
+      encodeBase64(key),
+    );
+    const sessionStore = new SynchPluginSessionStore({
+      plugin,
+      refreshUi: () => {},
+    });
+
+    await sessionStore.migrateLegacySecrets();
+
+    expect(plugin.app.secretStorage.getSecret("synch-session-token")).toBe("");
+    expect(plugin.app.secretStorage.getSecret("synch-remote-vault-key")).toBe("");
+
+    await expect(new ObsidianAuthSessionTokenStore(plugin).read()).resolves.toBe(
+      "legacy-token",
+    );
+    await sessionStore.loadStoredRemoteVaultKeySecret();
+    expect(sessionStore.getStoredRemoteVaultKeySecret()).toEqual({
+      remoteVaultKey: key,
+    });
+  });
+
+  it("stores and migrates session tokens per vault", async () => {
+    const pluginA = createPlugin("scope-a");
+    const pluginB = createPlugin("scope-b");
+    const storeA = new ObsidianAuthSessionTokenStore(pluginA);
+    const storeB = new ObsidianAuthSessionTokenStore(pluginB);
+    pluginA.app.secretStorage.setSecret("synch-session-token", "legacy-token");
+
+    await storeA.write(" token-a ");
+    await storeB.write(" token-b ");
+
+    expect(
+      pluginA.app.secretStorage.getSecret("synch-session-token-scope-a"),
+    ).toBe("token-a");
+    expect(
+      pluginB.app.secretStorage.getSecret("synch-session-token-scope-b"),
+    ).toBe("token-b");
+    expect(pluginA.app.secretStorage.getSecret("synch-session-token")).toBe("");
+    await expect(storeA.read()).resolves.toBe("token-a");
+    await expect(storeB.read()).resolves.toBe("token-b");
+  });
+
+  it("migrates a legacy session token and does not restore it after clear", async () => {
+    const plugin = createPlugin("scope-a");
+    const store = new ObsidianAuthSessionTokenStore(plugin);
+    plugin.app.secretStorage.setSecret("synch-session-token", "legacy-token");
+
+    await expect(store.read()).resolves.toBe("");
+    await migrateLegacyAuthSessionToken(plugin);
+    await expect(store.read()).resolves.toBe("legacy-token");
+    expect(
+      plugin.app.secretStorage.getSecret("synch-session-token-scope-a"),
+    ).toBe("legacy-token");
+
+    await clearAuthSessionToken(plugin);
+
+    await expect(store.read()).resolves.toBe("");
+    expect(plugin.app.secretStorage.getSecret("synch-session-token")).toBe("");
+  });
+
+  it("keeps the secret scope when the sync local vault id is reset", () => {
+    const plugin = new TestPlugin();
+    const secretScopeId = getOrCreateSecretScopeId(plugin);
+
+    clearLocalVaultId(plugin);
+
+    expect(getOrCreateSecretScopeId(plugin)).toBe(secretScopeId);
+  });
+});
+
+function createPlugin(secretScopeId: string): Plugin {
+  const plugin = new TestPlugin();
+  plugin.app.saveLocalStorage("synch.secretScopeId", secretScopeId);
+  return plugin;
+}

--- a/apps/obsidian-plugin/src/app/__tests__/readiness-helpers.ts
+++ b/apps/obsidian-plugin/src/app/__tests__/readiness-helpers.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from "obsidian";
 import { vi } from "vitest";
 
+import { encodeBase64 } from "@synch/vault-crypto";
 import { writeAuthSessionToken } from "../../adapters/auth-session-storage";
 import { writeStoredRemoteVaultKeySecret } from "../../adapters/remote-vault-device-storage";
 import { DEFAULT_SYNC_FILE_RULES } from "@synch/sync-client/sync/core/file-rules";
@@ -16,6 +17,7 @@ const TestPlugin = TestPluginClass as unknown as new () => Plugin;
 
 export async function createConnectedPlugin(
   settingsOverrides: Partial<SynchPluginSettings> = {},
+  options: { legacySecrets?: boolean } = {},
 ): Promise<Plugin & { savedData: Record<string, unknown> | null }> {
   const plugin = new TestPlugin() as Plugin & {
     savedData: Record<string, unknown> | null;
@@ -27,10 +29,17 @@ export async function createConnectedPlugin(
   plugin.saveData = async (value: unknown) => {
     plugin.savedData = value as Record<string, unknown>;
   };
-  await writeAuthSessionToken(plugin, "stored-token");
-  await writeStoredRemoteVaultKeySecret(plugin, {
-    remoteVaultKey: new Uint8Array(32).fill(1),
-  });
+  const remoteVaultKey = new Uint8Array(32).fill(1);
+  if (options.legacySecrets) {
+    plugin.app.secretStorage.setSecret("synch-session-token", "stored-token");
+    plugin.app.secretStorage.setSecret(
+      "synch-remote-vault-key",
+      encodeBase64(remoteVaultKey),
+    );
+  } else {
+    await writeAuthSessionToken(plugin, "stored-token");
+    await writeStoredRemoteVaultKeySecret(plugin, { remoteVaultKey });
+  }
   return plugin;
 }
 

--- a/apps/obsidian-plugin/src/app/plugin-controller-readiness.test.ts
+++ b/apps/obsidian-plugin/src/app/plugin-controller-readiness.test.ts
@@ -5,6 +5,8 @@ import {
   resetObsidianMocks,
   setRequestUrlMock,
 } from "../test-stubs/obsidian";
+import { readAuthSessionToken } from "../adapters/auth-session-storage";
+import { readStoredRemoteVaultKeySecret } from "../adapters/remote-vault-device-storage";
 import { t } from "../i18n";
 import { SyncController } from "./sync-controller";
 import { SynchPluginController } from "./plugin-controller";
@@ -22,6 +24,35 @@ describe("SynchPluginController readiness reconciliation", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("migrates legacy credentials before authenticating and restoring the vault", async () => {
+    const plugin = await createConnectedPlugin({}, { legacySecrets: true });
+    mockOnlineReadinessRequests();
+    vi.spyOn(SyncController.prototype, "readStoredConnection").mockResolvedValue(
+      storedConnection(),
+    );
+    vi.spyOn(SyncController.prototype, "initializeStore").mockResolvedValue();
+    const controller = new SynchPluginController({
+      plugin,
+      refreshUi: vi.fn(),
+    });
+
+    await controller.initialize();
+
+    await expect(readAuthSessionToken(plugin)).resolves.toBe("stored-token");
+    await expect(readStoredRemoteVaultKeySecret(plugin)).resolves.toEqual({
+      remoteVaultKey: new Uint8Array(32).fill(1),
+    });
+
+    await controller.ensureAutoSyncState();
+
+    expect(controller.getAuthStatusLabel()).toBe(
+      t("auth.signedIn", { name: "user@example.com" }),
+    );
+    expect(controller.getRemoteVaultStatusLabel()).toBe(
+      t("vault.loaded", { label: "Recovered" }),
+    );
   });
 
   it("keeps startup offline as offline instead of treating the stored token as rejected", async () => {

--- a/apps/obsidian-plugin/src/app/plugin-controller.ts
+++ b/apps/obsidian-plugin/src/app/plugin-controller.ts
@@ -257,9 +257,10 @@ export class SynchPluginController implements SynchSettingsController {
 
   async initialize(): Promise<void> {
     await this.pluginDataStore.initialize();
+    await this.sessionStore.migrateLegacySecrets();
+    await this.sessionStore.loadStoredRemoteVaultKeySecret();
     await this.initializeSettings();
     await this.updateService.checkServerCompatibility();
-    await this.sessionStore.loadStoredRemoteVaultKeySecret();
     this.sessionStore.setStoredSyncConnection(
       await this.syncController.readStoredConnection(),
     );

--- a/apps/obsidian-plugin/src/app/session-store.ts
+++ b/apps/obsidian-plugin/src/app/session-store.ts
@@ -3,9 +3,11 @@ import type { Plugin } from "obsidian";
 import type { StoredRemoteVaultKeySecret } from "@synch/sync-client/remote-vault/types";
 import {
   clearStoredRemoteVaultKeySecret,
+  migrateLegacyRemoteVaultKeySecret,
   readStoredRemoteVaultKeySecret,
   writeStoredRemoteVaultKeySecret,
 } from "../adapters/remote-vault-device-storage";
+import { migrateLegacyAuthSessionToken } from "../adapters/auth-session-storage";
 import type { SyncConnection } from "@synch/sync-client/sync/store/store";
 
 export interface SynchPluginSessionStoreDeps {
@@ -19,10 +21,13 @@ export class SynchPluginSessionStore {
 
   constructor(private readonly deps: SynchPluginSessionStoreDeps) {}
 
+  async migrateLegacySecrets(): Promise<void> {
+    await migrateLegacyAuthSessionToken(this.deps.plugin);
+    await migrateLegacyRemoteVaultKeySecret(this.deps.plugin);
+  }
+
   async loadStoredRemoteVaultKeySecret(): Promise<void> {
-    this.storedRemoteVaultKeySecret = await readStoredRemoteVaultKeySecret(
-      this.deps.plugin,
-    );
+    this.storedRemoteVaultKeySecret = await readStoredRemoteVaultKeySecret(this.deps.plugin);
   }
 
   getStoredRemoteVaultKeySecret(): StoredRemoteVaultKeySecret | null {

--- a/apps/obsidian-plugin/src/test-stubs/obsidian.ts
+++ b/apps/obsidian-plugin/src/test-stubs/obsidian.ts
@@ -312,6 +312,10 @@ export class App {
   secretStorage = {
     getSecret: (key: string): string | undefined => this.secrets.get(key),
     setSecret: (key: string, value: string): void => {
+      if (!/^[a-z0-9-]+$/.test(key)) {
+        throw new Error("Invalid secret ID");
+      }
+
       this.secrets.set(key, value);
     },
   };

--- a/docs/secret-storage-migration.md
+++ b/docs/secret-storage-migration.md
@@ -1,0 +1,72 @@
+# Vault-scoped secret storage
+
+## Context
+
+The Obsidian plugin previously stored the remote vault key and device session
+token under fixed secret names. When multiple vaults used the same Obsidian
+installation, a fixed name did not make the intended vault relationship
+explicit and could allow one vault's credential to be read while another vault
+was active.
+
+The plugin now namespaces both credentials with a stable identifier belonging
+to the current Obsidian vault.
+
+## Storage model
+
+On first access, the plugin creates a UUID and stores it in Obsidian's
+vault-local plugin storage as `synch.secretScopeId`. The UUID is only a
+namespace identifier; it is not the remote vault key or the session token.
+
+Scoped secret names are:
+
+```text
+synch-remote-vault-key-<secretScopeId>
+synch-session-token-<secretScopeId>
+```
+
+The scope ID survives plugin reloads, application restarts, and sync-store
+resets. It is intentionally separate from `synch.localVaultId`, which is
+cleared when local sync state is reset. The scope ID and the secrets are stored
+locally by Obsidian; they are not synced as vault files or sent to the Synch
+server.
+
+## Legacy migration
+
+The old fixed-name secrets remain readable only during the plugin's startup
+migration:
+
+1. Initialize the plugin data store.
+2. If the scoped value is absent, copy the legacy value into the scoped name.
+3. After the scoped value is written successfully, clear the legacy secret.
+4. Read credentials from the scoped names for the remainder of the session.
+
+Session tokens and remote vault keys are migrated before authentication,
+connection loading, or readiness checks. Migration copies the value and then
+clears the old fixed-name secret.
+
+New writes and clears use the scoped secret and clear the old fixed-name
+secret. Errors encountered while reading or migrating are treated as missing
+credentials so an unusual storage failure does not crash plugin startup or
+make the plugin continue with an uncertain key.
+
+## Non-goals
+
+This change is local secret namespacing. It does not:
+
+- repair existing server data that was encrypted with the wrong key;
+- rotate vault keys or re-encrypt pending mutations.
+
+If copying the value fails before the scoped secret is written, the legacy
+value is left in place so a later startup can retry the migration.
+
+If Obsidian's vault-local plugin storage is removed, the scope ID is lost and a
+new one is generated. The existing scoped credentials may then require the
+user to sign in or reconnect the remote vault again.
+
+## Implementation
+
+- Scope management: `apps/obsidian-plugin/src/adapters/secret-scope.ts`
+- Remote vault key storage: `apps/obsidian-plugin/src/adapters/remote-vault-device-storage.ts`
+- Session token storage: `apps/obsidian-plugin/src/adapters/auth-session-storage.ts`
+- Startup migration and scoped-only reads: `apps/obsidian-plugin/src/app/plugin-controller.ts` and `apps/obsidian-plugin/src/app/session-store.ts`
+- Regression coverage: `apps/obsidian-plugin/src/adapters/secret-storage.test.ts`


### PR DESCRIPTION
## Summary

- Scope session tokens and remote-vault keys per Obsidian vault.
- Migrate existing credentials from the legacy shared secret names.
- Add migration documentation and tests.

Resolves #28

## Tests

- pnpm -C apps/obsidian-plugin test --run
- pnpm -C apps/obsidian-plugin typecheck
- pnpm -C apps/obsidian-plugin lint