### PR TITLE
Fix/device authorization self hosted

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -41,6 +41,7 @@ export type AppDependencies = {
 
 export type AppConfig = {
 	corsOrigin: string;
+	authBaseUrl: string;
 	adminToken?: string;
 };
 
@@ -57,7 +58,7 @@ export function createApp(deps: AppDependencies, config: AppConfig): Hono {
 		}),
 	);
 
-	registerAuthRoutes(app, deps.authHttpHandler);
+	registerAuthRoutes(app, deps.authHttpHandler, config.authBaseUrl);
 	app.get("/health", (c) =>
 		c.json({
 			ok: true,

--- a/apps/api/src/auth/routes.test.ts
+++ b/apps/api/src/auth/routes.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeDeviceAuthorizationRequest } from "./routes";
+
+const AUTH_ORIGIN = "https://synch.example.com";
+
+function deviceRequest(url: string, headers: Record<string, string> = {}): Request {
+	return new Request(url, {
+		method: "POST",
+		headers: {
+			"content-type": "application/json",
+			...headers,
+		},
+		body: JSON.stringify({ client_id: "synch-obsidian-plugin" }),
+	});
+}
+
+describe("normalizeDeviceAuthorizationRequest", () => {
+	it("drops a session cookie left over in the client's cookie jar", () => {
+		// Obsidian mobile shares cookies between its in-app browser and requestUrl,
+		// and Better Auth rejects these endpoints outright when a cookie rides along.
+		const normalized = normalizeDeviceAuthorizationRequest(
+			deviceRequest("https://synch.example.com/api/auth/device/code", {
+				cookie: "better-auth.session_token=stale",
+				origin: "app://obsidian.md",
+			}),
+			AUTH_ORIGIN,
+		);
+
+		expect(normalized.headers.get("cookie")).toBeNull();
+		expect(normalized.headers.get("origin")).toBe("https://synch.example.com");
+		expect(normalized.headers.get("referer")).toBe("https://synch.example.com/device");
+	});
+
+	it("drops cookies on the token endpoint too", () => {
+		const normalized = normalizeDeviceAuthorizationRequest(
+			deviceRequest("https://synch.example.com/api/auth/device/token", {
+				cookie: "unrelated=value",
+			}),
+			AUTH_ORIGIN,
+		);
+
+		expect(normalized.headers.get("cookie")).toBeNull();
+	});
+
+	it("keeps the request body intact", async () => {
+		const normalized = normalizeDeviceAuthorizationRequest(
+			deviceRequest("https://synch.example.com/api/auth/device/code", {
+				cookie: "better-auth.session_token=stale",
+			}),
+			AUTH_ORIGIN,
+		);
+
+		await expect(normalized.json()).resolves.toEqual({
+			client_id: "synch-obsidian-plugin",
+		});
+	});
+
+	it("leaves cookies on other auth requests", () => {
+		const request = deviceRequest("https://synch.example.com/api/auth/sign-in/email", {
+			cookie: "better-auth.session_token=live",
+		});
+
+		const normalized = normalizeDeviceAuthorizationRequest(request, AUTH_ORIGIN);
+
+		expect(normalized).toBe(request);
+		expect(normalized.headers.get("cookie")).toBe("better-auth.session_token=live");
+	});
+
+	it("leaves non-POST device requests untouched", () => {
+		const request = new Request("https://synch.example.com/api/auth/device/code", {
+			method: "GET",
+			headers: { cookie: "better-auth.session_token=live" },
+		});
+
+		expect(normalizeDeviceAuthorizationRequest(request, AUTH_ORIGIN)).toBe(request);
+	});
+
+	it("pins the origin to PUBLIC_URL when a TLS-terminating proxy hands over http", () => {
+		// nginx terminates TLS and proxies to the container over plain http, so the
+		// request URL arrives on http even though clients reached it over https.
+		const normalized = normalizeDeviceAuthorizationRequest(
+			deviceRequest("http://synch.example.com/api/auth/device/code", {
+				origin: "app://obsidian.md",
+			}),
+			AUTH_ORIGIN,
+		);
+
+		expect(normalized.headers.get("origin")).toBe("https://synch.example.com");
+		expect(normalized.headers.get("referer")).toBe("https://synch.example.com/device");
+	});
+});

--- a/apps/api/src/auth/routes.ts
+++ b/apps/api/src/auth/routes.ts
@@ -5,7 +5,9 @@ export type AuthHttpHandler = (request: Request) => Promise<Response>;
 export function registerAuthRoutes(
 	app: Hono,
 	authHttpHandler: AuthHttpHandler,
+	authBaseUrl: string,
 ): void {
+	const authOrigin = new URL(authBaseUrl).origin;
 	app.get("/verify-email", (c) => {
 		const url = new URL(c.req.url);
 		url.pathname = "/api/auth/verify-email";
@@ -15,21 +17,32 @@ export function registerAuthRoutes(
 		authHttpHandler(
 			normalizeDeviceAuthorizationRequest(
 				normalizeBearerSessionRequest(c.req.raw),
+				authOrigin,
 			),
 		),
 	);
 }
 
-export function normalizeDeviceAuthorizationRequest(request: Request): Request {
+export function normalizeDeviceAuthorizationRequest(
+	request: Request,
+	authOrigin: string,
+): Request {
 	if (!isDeviceAuthorizationClientRequest(request)) {
 		return request;
 	}
 
-	const url = new URL(request.url);
 	const headers = new Headers(request.headers);
-	// Native Obsidian mobile can send "null" or app-scheme origins for device flow requests.
-	headers.set("origin", url.origin);
-	headers.set("referer", `${url.origin}/device`);
+	// Native Obsidian mobile can send "null" or app-scheme origins for device flow
+	// requests. Pin to the configured auth origin rather than the request's own:
+	// behind a TLS-terminating proxy the request URL arrives on http, which never
+	// matches the trusted origins built from PUBLIC_URL.
+	headers.set("origin", authOrigin);
+	headers.set("referer", `${authOrigin}/device`);
+	// The device endpoints are unauthenticated by design, and Obsidian's mobile HTTP
+	// stack shares a cookie jar with its in-app browser: a cookie left over from
+	// visiting this host rides along and Better Auth then rejects the request as
+	// INVALID_ORIGIN no matter what the origin header says.
+	headers.delete("cookie");
 
 	return new Request(request, {
 		headers,

--- a/apps/api/src/composition/create-api-application.ts
+++ b/apps/api/src/composition/create-api-application.ts
@@ -104,6 +104,7 @@ export function createApiApplication(
 			},
 			{
 				corsOrigin: config.corsOrigin,
+				authBaseUrl: config.auth.baseURL,
 				adminToken: config.adminToken,
 			},
 		),

--- a/packages/sync-client/src/auth/client.test.ts
+++ b/packages/sync-client/src/auth/client.test.ts
@@ -33,6 +33,28 @@ describe("AuthClient", () => {
     });
   });
 
+  it("surfaces the server error when device authorization is rejected", async () => {
+    const { client } = createClient({
+      status: 403,
+      json: {
+        code: "INVALID_ORIGIN",
+        message: "Invalid origin",
+      },
+    });
+
+    await expect(
+      client.startDeviceAuthorization("https://api.example.com"),
+    ).rejects.toThrow("device authorization failed with status 403: Invalid origin");
+  });
+
+  it("reports the status when a rejected device authorization has no error body", async () => {
+    const { client } = createClient({ status: 502 });
+
+    await expect(
+      client.startDeviceAuthorization("https://api.example.com"),
+    ).rejects.toThrow("device authorization failed with status 502");
+  });
+
   it("maps pending and approved device token responses", async () => {
     const responses: HttpResponseLike[] = [
       {

--- a/packages/sync-client/src/auth/client.ts
+++ b/packages/sync-client/src/auth/client.ts
@@ -1,4 +1,9 @@
-import { stripTrailingSlash, type HttpClient } from "../http/request";
+import {
+  extractErrorCode,
+  extractErrorMessage,
+  stripTrailingSlash,
+  type HttpClient,
+} from "../http/request";
 
 export interface DeviceAuthorizationStart {
   deviceCode: string;
@@ -80,7 +85,17 @@ export class AuthClient {
       }),
     });
 
-    const json = response.json as Partial<{
+    if (response.status !== 200) {
+      const detail =
+        extractErrorMessage(response.json) || extractErrorCode(response.json);
+      throw new Error(
+        detail
+          ? `device authorization failed with status ${response.status}: ${detail}`
+          : `device authorization failed with status ${response.status}`,
+      );
+    }
+
+    const json = (response.json ?? {}) as Partial<{
       device_code: string;
       user_code: string;
       verification_uri: string;


### PR DESCRIPTION
## What

Device authorization (`POST /api/auth/device/code`) returns
`403 INVALID_ORIGIN` on self-hosted Node deployments behind a
TLS-terminating reverse proxy, making it impossible to sign in.

Two independent causes, both fixed here:

1. `normalizeDeviceAuthorizationRequest` synthesized the origin from
   `new URL(request.url).origin`. Behind a proxy that terminates TLS, the
   request reaches the app over plain http, so it wrote `http://host` while
   `trustedOrigins` is built from `PUBLIC_URL` (`https://host`). The
   normalization silently did the opposite of its purpose. It now pins to the
   configured auth origin, which is trusted by construction and does not rely
   on client-supplied headers such as `X-Forwarded-Proto`.

2. Any cookie on the request makes Better Auth run the origin check at all
   (without one it is skipped). Obsidian mobile's `requestUrl` shares a cookie
   jar with its in-app browser, so a cookie left over from visiting the host
   rides along on every request. These endpoints are unauthenticated by
   design, so the cookie is now dropped — mirroring what
   `normalizeBearerSessionRequest` already did just below.

Not reproducible on the Cloudflare deployment: workerd preserves the https
scheme in `request.url`, so the synthesized origin matches. Only the
Docker/systemd self-host guide's topology is affected.

## Reproduction

Against a self-hosted Node instance behind a TLS-terminating proxy:

    curl -i -X POST https://your-server/api/auth/device/code \
      -H 'content-type: application/json' \
      -H 'Cookie: foo=bar' \
      -d '{"client_id":"synch-obsidian-plugin"}'

Before: `403 {"message":"Invalid origin","code":"INVALID_ORIGIN"}`.
After: `200` with the device code. Any non-empty cookie triggers it — it does
not need to be a session cookie.

## Testing

- New `apps/api/src/auth/routes.test.ts` covers cookie removal on both device
  endpoints, origin pinning when the request arrives over http, body
  preservation, and that other auth routes keep cookies and origin checks.
- `pnpm -C apps/api test:unit`, `test:integration:cloudflare`, `typecheck`.
- Verified end to end on a self-hosted instance (nginx terminating TLS,
  container on a mapped port): Obsidian mobile sign-in fails before and
  succeeds after.

## Note for review

The sync-client commit is a separate concern but worth keeping: the failure
was invisible because `startDeviceAuthorization` was the only method in the
file that ignored the HTTP status, collapsing every server error into
"invalid device authorization response".