### PR TITLE
Fix localhost self-hosted device sign-in browser flow

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -9,6 +9,7 @@ import type { BillingService } from "./billing/application";
 import { mapBillingApplicationError } from "./billing/adapters/inbound/http/error-mapper";
 import { onError } from "./errors";
 import { registerPluginVersionRoutes } from "./plugin-version/routes";
+import { registerRedirectRoutes } from "./redirect/routes";
 import type { SubscriptionPolicyReader } from "./subscription/application";
 import type { IssueSyncToken } from "./sync-access/application";
 import { mapSyncAccessApplicationError } from "./sync-access/adapters/inbound/http/error-mapper";
@@ -66,6 +67,7 @@ export function createApp(deps: AppDependencies, config: AppConfig): Hono {
 		}),
 	);
 	registerPluginVersionRoutes(app);
+	registerRedirectRoutes(app);
 	registerSyncAccessRoutes(app, {
 		syncTokenIssuer: deps.syncTokenIssuer,
 		sessionReader: deps.sessionReader,

--- a/apps/api/src/redirect/routes.test.ts
+++ b/apps/api/src/redirect/routes.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { getLoopbackTarget } from "./routes";
+
+describe("localhost redirect target", () => {
+	it("accepts loopback HTTP(S) URLs with their query intact", () => {
+		expect(
+			getLoopbackTarget(
+				"http://localhost:8787/device?user_code=ABC&return_uri=obsidian%3A%2F%2Fsynch-device-login",
+			),
+		).toEqual(
+			new URL(
+				"http://localhost:8787/device?user_code=ABC&return_uri=obsidian%3A%2F%2Fsynch-device-login",
+			),
+		);
+	});
+
+	it("rejects non-loopback or non-HTTP(S) targets", () => {
+		expect(getLoopbackTarget("https://example.com/device")).toBeNull();
+		expect(getLoopbackTarget("javascript:alert(1)")).toBeNull();
+		expect(getLoopbackTarget("http://localhost:8787@evil.example/device")).toBeNull();
+		expect(getLoopbackTarget("http://localhost:8787/admin")).toBeNull();
+	});
+});

--- a/apps/api/src/redirect/routes.ts
+++ b/apps/api/src/redirect/routes.ts
@@ -1,0 +1,47 @@
+import type { Context, Hono } from "hono";
+
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export function registerRedirectRoutes(app: Hono): void {
+	app.get("/redirect", handleRedirect);
+	app.get("/redirect/", handleRedirect);
+}
+
+function handleRedirect(c: Context) {
+	const target = getLoopbackTarget(c.req.query("url"));
+	if (!target) {
+		return c.json(
+			{
+				error: "invalid_redirect_target",
+				message: "A localhost HTTP(S) URL is required.",
+			},
+			400,
+		);
+	}
+
+	c.header("Cache-Control", "no-store");
+	return c.redirect(target.toString(), 302);
+}
+
+export function getLoopbackTarget(value: string | undefined): URL | null {
+	if (!value) {
+		return null;
+	}
+
+	try {
+		const target = new URL(value);
+		if (
+			(target.protocol !== "http:" && target.protocol !== "https:") ||
+			target.username ||
+			target.password ||
+			(target.pathname !== "/device" && target.pathname !== "/device/") ||
+			!LOOPBACK_HOSTS.has(target.hostname)
+		) {
+			return null;
+		}
+
+		return target;
+	} catch {
+		return null;
+	}
+}

--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -6,4 +6,6 @@
 
 ## Changed
 
+- Open self-hosted device sign-in pages through an external browser when they use localhost.
+
 ## Fixed

--- a/apps/obsidian-plugin/src/adapters/external-browser.ts
+++ b/apps/obsidian-plugin/src/adapters/external-browser.ts
@@ -1,5 +1,32 @@
 export const SYNCH_DEVICE_LOGIN_RETURN_URI = "obsidian://synch-device-login";
+export const SYNCH_LOCALHOST_REDIRECT_URL = "https://api.synch.run/redirect/";
 
-export function openExternalUrl(url: string): void {
-  window.open(url, "_external", "noopener,noreferrer");
+export function openExternalUrl(
+	url: string,
+	options: { redirectLocalhost?: boolean } = {},
+): void {
+	window.open(
+		options.redirectLocalhost ? redirectLocalhostUrl(url) : url,
+		"_external",
+		"noopener,noreferrer",
+	);
+}
+
+function redirectLocalhostUrl(url: string): string {
+	try {
+		const target = new URL(url);
+		if (!isLoopbackHost(target.hostname)) {
+			return url;
+		}
+
+		const redirect = new URL(SYNCH_LOCALHOST_REDIRECT_URL);
+		redirect.searchParams.set("url", target.toString());
+		return redirect.toString();
+	} catch {
+		return url;
+	}
+}
+
+function isLoopbackHost(hostname: string): boolean {
+	return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]";
 }

--- a/apps/obsidian-plugin/src/app/plugin-controller.ts
+++ b/apps/obsidian-plugin/src/app/plugin-controller.ts
@@ -116,7 +116,8 @@ export class SynchPluginController implements SynchSettingsController {
     },
     getLocale: () => getSynchLocale(),
     deviceLoginReturnUri: SYNCH_DEVICE_LOGIN_RETURN_URI,
-    openExternalUrl,
+    openExternalUrl: (url) =>
+      openExternalUrl(url, { redirectLocalhost: true }),
     notify: (event) => {
       new Notice(
         formatAuthNotice(event, this.authManager.getAuthStatus()),


### PR DESCRIPTION
## Summary

- Add a localhost-only redirect route for self-hosted device sign-in pages.
- Route Obsidian self-hosted device login through the external browser relay.
- Update the Obsidian plugin release notes.

Related to #30 

## Tests

- Focused redirect tests passed.
- Obsidian plugin tests, lint, typecheck, and build passed.
- API typecheck passed.