### PR TITLE
ci: update GitHub Actions Node.js runtimes

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -33,11 +33,11 @@ jobs:
       api-affected: ${{ steps.affected.outputs.affected }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
@@ -53,13 +53,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/obsidian-plugin-ci.yml
+++ b/.github/workflows/obsidian-plugin-ci.yml
@@ -33,11 +33,11 @@ jobs:
       since-filter: ${{ steps.affected.outputs.since-filter }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
@@ -58,15 +58,15 @@ jobs:
       SINCE_FILTER: ${{ needs.detect.outputs.since-filter }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release-obsidian-plugin.yml
+++ b/.github/workflows/release-obsidian-plugin.yml
@@ -66,7 +66,7 @@ jobs:
       - run: pnpm -C apps/obsidian-plugin build
 
       - name: Generate release artifact attestation
-        uses: actions/attest@v3
+        uses: actions/attest@v4
         with:
           subject-path: |
             apps/obsidian-plugin/dist/main.js

--- a/.github/workflows/release-obsidian-plugin.yml
+++ b/.github/workflows/release-obsidian-plugin.yml
@@ -32,15 +32,15 @@ jobs:
       API_BASE_URL: ${{ vars.OBSIDIAN_PLUGIN_API_BASE_URL }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -66,7 +66,7 @@ jobs:
       - run: pnpm -C apps/obsidian-plugin build
 
       - name: Generate release artifact attestation
-        uses: actions/attest@v4
+        uses: actions/attest@v3
         with:
           subject-path: |
             apps/obsidian-plugin/dist/main.js
@@ -93,7 +93,7 @@ jobs:
           git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/sync-client-benchmark.yml
+++ b/.github/workflows/sync-client-benchmark.yml
@@ -36,17 +36,17 @@ jobs:
 
     steps:
       - name: Checkout PR merge ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.issue.number }}/merge
           fetch-depth: 1
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -62,7 +62,7 @@ jobs:
 
       - name: Upload benchmark result
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sync-client-benchmark-${{ github.run_id }}
           path: ${{ runner.temp }}/sync-client-benchmark.json
@@ -82,14 +82,14 @@ jobs:
 
     steps:
       - name: Checkout default branch scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
           persist-credentials: false
 
       - name: Download benchmark result
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         continue-on-error: true
         with:
           name: sync-client-benchmark-${{ github.run_id }}

--- a/.github/workflows/www-deploy.yml
+++ b/.github/workflows/www-deploy.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary

- Update GitHub Actions dependencies to Node.js 24-compatible versions
- Update artifact upload/download actions used by benchmark workflows
- Update release action versions

Fixes #34

## Verification

- `git diff --check`
- Parsed all `.github/workflows/*.yml` files with Ruby YAML parser