### PR TITLE
Fix interrupted upload recovery and retryable repair pauses

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -32,9 +32,16 @@ AUTH_ALLOWED_EMAILS=you@example.com,family@example.com
 # HOST=127.0.0.1
 
 # Blob storage backend: "disk" (default, stored under the data volume) or "s3".
+# Disk uploads use <blob-directory>.uploads/*.part beside the blob directory.
+# Keep both directories on the same filesystem. With a single server using
+# the storage, abandoned parts are removed before accepting requests.
 # BLOB_STORAGE=s3
 # S3_ENDPOINT=https://your-s3-compatible-endpoint
 # S3_BUCKET=synch-blobs
 # S3_REGION=auto
 # S3_ACCESS_KEY_ID=
 # S3_SECRET_ACCESS_KEY=
+
+# Total time allowed to receive an HTTP request, in milliseconds (default 300000).
+# For slow uploads, increase up to 1500000 (25 minutes); also check your proxy.
+# REQUEST_TIMEOUT_MS=900000

--- a/apps/api/src/config/node.test.ts
+++ b/apps/api/src/config/node.test.ts
@@ -21,6 +21,15 @@ describe("Node server config", () => {
 		});
 	});
 
+	it("keeps request timeouts finite and below staged GC expiry", () => {
+		expect(parseNodeServerConfig(requiredEnv).requestTimeoutMs).toBe(300_000);
+		expect(parseNodeServerConfig({ ...requiredEnv, REQUEST_TIMEOUT_MS: "900000" }))
+			.toMatchObject({ requestTimeoutMs: 900_000 });
+		for (const value of ["0", "-1", "1500001", "NaN"]) {
+			expect(() => parseNodeServerConfig({ ...requiredEnv, REQUEST_TIMEOUT_MS: value })).toThrow();
+		}
+	});
+
 	it("validates and returns an S3 configuration", () => {
 		const config = parseNodeServerConfig({
 			...requiredEnv,

--- a/apps/api/src/config/node.ts
+++ b/apps/api/src/config/node.ts
@@ -8,6 +8,8 @@ const optionalNonBlankString = z.preprocess(
 const nodeEnvSchema = z.object({
 	DATA_DIR: optionalNonBlankString.default("./data"),
 	PORT: z.coerce.number().int().min(1).max(65_535).default(8787),
+	// Keep uploads below the coordinator's 30-minute staged-blob GC grace.
+	REQUEST_TIMEOUT_MS: z.coerce.number().int().positive().max(25 * 60_000).default(300_000),
 	HOST: optionalNonBlankString.default("0.0.0.0"),
 	PUBLIC_URL: optionalNonBlankString,
 	CORS_ORIGIN: optionalNonBlankString,
@@ -41,6 +43,7 @@ export type NodeBlobConfig =
 export type NodeServerConfig = {
 	host: string;
 	port: number;
+	requestTimeoutMs: number;
 	dataDir: string;
 	publicUrl: string;
 	corsOrigin?: string;
@@ -63,6 +66,7 @@ export function parseNodeServerConfig(
 	return {
 		host: env.HOST,
 		port: env.PORT,
+		requestTimeoutMs: env.REQUEST_TIMEOUT_MS,
 		dataDir: env.DATA_DIR,
 		publicUrl,
 		corsOrigin,

--- a/apps/api/src/self-host.ts
+++ b/apps/api/src/self-host.ts
@@ -24,6 +24,8 @@ function createBlobStorage(config: NodeBlobConfig): BlobObjectStorage {
 
 async function main(): Promise<void> {
 	const config = parseNodeServerConfig(process.env);
+	const blobStorage = createBlobStorage(config.blob);
+	if (blobStorage instanceof LocalDiskBlobObjectStorage) await blobStorage.initialize();
 	// Defaults to all interfaces (needed for Docker's port publishing to work
 	// at all - binding to 127.0.0.1 inside a container makes it unreachable
 	// from outside its own network namespace). Set HOST=127.0.0.1 for a
@@ -37,7 +39,7 @@ async function main(): Promise<void> {
 		authAllowedEmails: config.authAllowedEmails,
 		syncTokenSecret: config.syncTokenSecret,
 		syncTokenTtlSeconds: config.syncTokenTtlSeconds,
-		blobStorage: createBlobStorage(config.blob),
+		blobStorage,
 	});
 
 	const webSockets = createNodeWebSocketUpgradeHandler(runtime, config.publicUrl);
@@ -46,6 +48,11 @@ async function main(): Promise<void> {
 		fetch: (request) => runtime.fetch(request),
 		port: config.port,
 		hostname: config.host,
+		serverOptions: {
+			requestTimeout: config.requestTimeoutMs,
+			headersTimeout: Math.min(60_000, config.requestTimeoutMs),
+			connectionsCheckingInterval: Math.min(30_000, config.requestTimeoutMs),
+		},
 	}) as NodeHttpServer;
 	server.on("upgrade", webSockets.handleUpgrade);
 

--- a/apps/api/src/sync-access/application/errors/sync-access-errors.ts
+++ b/apps/api/src/sync-access/application/errors/sync-access-errors.ts
@@ -21,8 +21,8 @@ export class SyncAccessApplicationError extends Error {
 
 /** Stable public error body for any inbound adapter that surfaces these failures. */
 export type SyncAccessPublicError = {
-	status: 401 | 403;
-	code: "unauthorized" | "forbidden";
+	status: 401 | 403 | 503;
+	code: "unauthorized" | "forbidden" | "sync_paused";
 	message: string;
 };
 
@@ -43,8 +43,8 @@ export const SYNC_ACCESS_PUBLIC_ERROR = {
 		message: "vault access denied",
 	},
 	sync_paused: {
-		status: 403,
-		code: "forbidden",
+		status: 503,
+		code: "sync_paused",
 		message: "vault sync is temporarily paused for repair",
 	},
 } as const satisfies Record<SyncAccessApplicationErrorCode, SyncAccessPublicError>;

--- a/apps/api/src/sync-blob-transfer/adapters/inbound/http/error-mapper.test.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/inbound/http/error-mapper.test.ts
@@ -4,16 +4,16 @@ import { BlobTransferApplicationError } from "../../../application/errors/blob-t
 import { mapBlobTransferApplicationError } from "./error-mapper";
 
 describe("mapBlobTransferApplicationError", () => {
-	it("maps paused-vault staging rejections to 403 forbidden", async () => {
+	it("maps paused-vault staging rejections to a retryable 503", async () => {
 		const response = mapBlobTransferApplicationError(
 			new BlobTransferApplicationError("coordinator_stage_rejected", {
-				reason: "forbidden",
+				reason: "sync_paused",
 				message: "vault sync is temporarily paused for repair",
 			}),
 		);
 
-		expect(response?.status).toBe(403);
-		await expect(response?.json()).resolves.toMatchObject({ error: "forbidden" });
+		expect(response?.status).toBe(503);
+		await expect(response?.json()).resolves.toMatchObject({ error: "sync_paused" });
 	});
 
 	it("maps coordinator error codes when the stage body has no reason", async () => {

--- a/apps/api/src/sync-blob-transfer/adapters/inbound/http/error-mapper.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/inbound/http/error-mapper.ts
@@ -1,12 +1,13 @@
 import { BlobTransferApplicationError } from "../../../application/errors/blob-transfer-errors";
 
 type CoordinatorStageRejection = {
-	status: 400 | 401 | 403 | 404 | 409 | 413;
+	status: 400 | 401 | 403 | 404 | 409 | 413 | 503;
 	code: string;
 	includeReason?: true;
 };
 
 const COORDINATOR_STAGE_REJECTION: Record<string, CoordinatorStageRejection> = {
+	sync_paused: { status: 503, code: "sync_paused" },
 	sync_state_uninitialized: {
 		status: 409,
 		code: "sync_state_uninitialized",

--- a/apps/api/src/sync-blob-transfer/adapters/inbound/http/routes.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/inbound/http/routes.ts
@@ -41,16 +41,30 @@ export function registerBlobTransferRoutes(
 					400,
 				);
 			}
-			return c.json(
-				await deps.uploadBlob.uploadBlob({
-					vaultId,
-					blobId,
-					declaredSizeBytes,
+			const startedAt = Date.now();
+			let receivedSizeBytes = 0;
+			const body = request.body.pipeThrough(new TransformStream<Uint8Array, Uint8Array>({
+				transform(chunk, controller) {
+					receivedSizeBytes += chunk.byteLength;
+					controller.enqueue(chunk);
+				},
+			}));
+			try {
+				return c.json(await deps.uploadBlob.uploadBlob({
+					vaultId, blobId, declaredSizeBytes,
 					token: parseBearerToken(request.headers.get("authorization")),
-					body: request.body,
-				}),
-				201,
-			);
+					body,
+				}), 201);
+			} catch (error) {
+				console.warn("[blob-transfer] upload failed", {
+					vaultId, blobId, declaredSizeBytes, receivedSizeBytes,
+					durationMs: Date.now() - startedAt,
+				});
+				throw error;
+			} finally {
+				// Pre-storage rejection (auth, quota, staging) must also stop reading.
+				if (!body.locked) await body.cancel().catch(() => {});
+			}
 		},
 	);
 

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/body-size.test.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/body-size.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { limitBodySize } from "./body-size";
+
+describe("upload body length and lifecycle", () => {
+	it.each([2, 4])("rejects a body of %i bytes when 3 are declared", async (size) => {
+		const limited = limitBodySize(new Response(new Uint8Array(size)).body!, 3);
+		const [consumer, sizeResult] = await Promise.allSettled([
+			new Response(limited.readable).arrayBuffer(), limited.sizeMismatch,
+		]);
+		expect(consumer.status).toBe("rejected");
+		expect(sizeResult).toEqual({ status: "fulfilled", value: true });
+	});
+
+	it("propagates an input failure to the consumer and completion", async () => {
+		const error = new Error("connection aborted");
+		const limited = limitBodySize(new ReadableStream({
+			start(controller) { controller.enqueue(new Uint8Array([1])); },
+			pull(controller) { controller.error(error); },
+		}), 3);
+		const results = await Promise.allSettled([
+			new Response(limited.readable).arrayBuffer(), limited.sizeMismatch,
+		]);
+		expect(results).toEqual([
+			{ status: "rejected", reason: error }, { status: "rejected", reason: error },
+		]);
+	});
+
+	it("cancels the input when the destination fails", async () => {
+		const error = new Error("disk full");
+		const cancel = vi.fn();
+		const limited = limitBodySize(new ReadableStream({
+			pull(controller) { controller.enqueue(new Uint8Array([1])); }, cancel,
+		}), 100);
+		const results = await Promise.allSettled([
+			limited.readable.pipeTo(new WritableStream({ write() { throw error; } })),
+			limited.sizeMismatch,
+		]);
+		expect(results.every((result) => result.status === "rejected")).toBe(true);
+		expect(cancel).toHaveBeenCalledWith(error);
+	});
+});

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/body-size.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/body-size.ts
@@ -1,56 +1,37 @@
 export interface SizeLimitedBody {
 	readable: ReadableStream<Uint8Array>;
+	/** Observe concurrently with the consumer: either side can fail first. */
 	sizeMismatch: Promise<boolean>;
 }
 
-/**
- * Stops consuming an upload as soon as it exceeds the declared size while
- * preserving backpressure. FixedLengthStream lets R2 retain a known length;
- * Node/S3 uses the standard TransformStream fallback.
- */
+class BlobBodySizeMismatchError extends Error {
+	constructor() {
+		super("blob body size did not match declared X-Blob-Size");
+	}
+}
+
+/** Enforces length while propagating input errors and downstream cancellation. */
 export function limitBodySize(
 	body: ReadableStream<Uint8Array>,
 	maxBytes: number,
 ): SizeLimitedBody {
-	const { readable, writable } = createLimitedStream(maxBytes);
-	const writer = writable.getWriter();
-	const reader = body.getReader();
-
-	const sizeMismatch = (async () => {
-		let received = 0;
-		let mismatch = false;
-		for (;;) {
-			const { done, value } = await reader.read();
-			if (done) {
-				break;
-			}
-			received += value.byteLength;
-			if (received > maxBytes) {
-				mismatch = true;
-				await reader.cancel().catch(() => {});
-				break;
-			}
-			await writer.write(value);
-		}
-		if (received !== maxBytes) {
-			mismatch = true;
-		}
-		if (mismatch) {
-			await writer.abort(new Error("blob body size did not match declared X-Blob-Size")).catch(
-				() => {},
-			);
-		} else {
-			await writer.close().catch(() => {});
-		}
-		return mismatch;
-	})();
-
-	return { readable, sizeMismatch };
-}
-
-function createLimitedStream(maxBytes: number): TransformStream<Uint8Array, Uint8Array> {
-	if (typeof FixedLengthStream === "undefined") {
-		return new TransformStream<Uint8Array, Uint8Array>();
-	}
-	return new FixedLengthStream(maxBytes);
+	let received = 0;
+	const limited = new TransformStream<Uint8Array, Uint8Array>({
+		transform(chunk, controller) {
+			received += chunk.byteLength;
+			if (received > maxBytes) throw new BlobBodySizeMismatchError();
+			controller.enqueue(chunk);
+		},
+		flush() {
+			if (received !== maxBytes) throw new BlobBodySizeMismatchError();
+		},
+	});
+	const sizeMismatch = body.pipeTo(limited.writable).then(
+		() => false,
+		(error: unknown) => {
+			if (error instanceof BlobBodySizeMismatchError) return true;
+			throw error;
+		},
+	);
+	return { readable: limited.readable, sizeMismatch };
 }

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/coordinator-blob-stager.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/coordinator-blob-stager.ts
@@ -32,20 +32,17 @@ export class CoordinatorBlobStagerAdapter implements CoordinatorBlobStager {
 	}
 
 	async abortStagedBlob(
-		input: Pick<BlobStageInput, "vaultId" | "blobId" | "token">,
+		input: Pick<BlobStageInput, "vaultId" | "blobId">,
 	): Promise<void> {
-		const headers = new Headers();
-		if (input.token) {
-			headers.set("authorization", `Bearer ${input.token}`);
-		}
-		// The previous proxy deliberately ignored this response. Keep cleanup
-		// best-effort so a failed abort never hides the original upload result.
-		await this.namespace.getByName(input.vaultId).fetch(
+		// Only callable through the internal coordinator namespace. The public
+		// upload was authenticated before staging; compensation outlives its JWT.
+		const response = await this.namespace.getByName(input.vaultId).fetch(
 			new Request(
 				`https://internal/internal/v1/vaults/${encodeURIComponent(input.vaultId)}/blobs/${encodeURIComponent(input.blobId)}/stage`,
-				{ method: "DELETE", headers },
+				{ method: "DELETE" },
 			),
 		);
+		if (!response.ok) throw new Error(`staged upload cleanup failed: ${response.status}`);
 	}
 }
 

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/local-disk-object-storage.test.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/local-disk-object-storage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync, readFileSync, mkdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -12,7 +12,9 @@ function streamOf(text: string): ReadableStream<Uint8Array> {
 describe("LocalDiskBlobObjectStorage", () => {
 	let dir = "";
 	afterEach(() => {
-		if (dir) rmSync(dir, { recursive: true, force: true });
+		if (dir) {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("round-trips and isolates vault prefixes", async () => {
@@ -57,11 +59,94 @@ describe("LocalDiskBlobObjectStorage", () => {
 		expect(await storage.exists("vault-1/blob-2")).toBe(false);
 	});
 
+	it.each(["input_error", "short", "long"])("cleans up a %s upload and permits a subsequent retry", async (failure) => {
+		dir = mkdtempSync(path.join(tmpdir(), "synch-blob-disk-"));
+		const storage = new LocalDiskBlobObjectStorage(dir);
+		let controller!: ReadableStreamDefaultController<Uint8Array>;
+		const interrupted = new ReadableStream<Uint8Array>({ start(c) { controller = c; } });
+		const failedAttempt = storage.upload("vault/blob", interrupted, 4);
+		const settled = Promise.allSettled([failedAttempt]);
+		controller.enqueue(new TextEncoder().encode("x"));
+		if (failure === "input_error") controller.error(new Error("connection reset"));
+		else {
+			if (failure === "long") controller.enqueue(new Uint8Array(4));
+			controller.close();
+		}
+		const [result] = await settled;
+		if (failure === "input_error") expect(result.status).toBe("rejected");
+		else expect(result).toMatchObject({ status: "fulfilled", value: { sizeMismatch: true } });
+		expect(await storage.exists("vault/blob")).toBe(false);
+		expect(readdirSync(path.join(dir, "vault"))).toEqual([]);
+		await storage.upload("vault/blob", streamOf("good"), 4);
+		expect(await new Response(await storage.download("vault/blob")).text()).toBe("good");
+		expect(readdirSync(path.join(dir, "vault"))).toEqual(["blob"]);
+	});
+
 	it("rejects traversal keys", async () => {
 		dir = mkdtempSync(path.join(tmpdir(), "synch-blob-disk-"));
 		const storage = new LocalDiskBlobObjectStorage(dir);
 		await expect(storage.upload("../escape", streamOf("x"), 1)).rejects.toThrow(
 			/must not contain "\.\." segments/,
 		);
+	});
+
+	it.each(["input_error", "short", "long"])("preserves a completed retry when an overlapping upload fails (%s)", async (failure) => {
+		dir = mkdtempSync(path.join(tmpdir(), "synch-blob-race-"));
+		const storage = new LocalDiskBlobObjectStorage(dir);
+		let controller!: ReadableStreamDefaultController<Uint8Array>;
+		const first = storage.upload("vault/blob", new ReadableStream({ start(c) { controller = c; } }), 4);
+		const settled = Promise.allSettled([first]);
+		controller.enqueue(new TextEncoder().encode("x"));
+		await expect.poll(() => {
+			try {
+				const part = readdirSync(path.join(dir, ".uploads")).find(name => name.endsWith(".part"));
+				return part ? readFileSync(path.join(dir, ".uploads", part)).length : 0;
+			} catch { return 0; }
+		}).toBe(1);
+		expect(await storage.download("vault/blob")).toBeNull();
+		await storage.upload("vault/blob", streamOf("good"), 4);
+		if (failure === "input_error") controller.error(new Error("disconnected"));
+		else {
+			if (failure === "long") controller.enqueue(new Uint8Array(4));
+			controller.close();
+		}
+		await settled;
+		expect(await new Response(await storage.download("vault/blob")).text()).toBe("good");
+		expect(readdirSync(path.join(dir, ".uploads"))).toEqual([]);
+	});
+
+	it("cleans abandoned parts at startup without touching completed blobs", async () => {
+		dir = mkdtempSync(path.join(tmpdir(), "synch-blob-startup-"));
+		const first = new LocalDiskBlobObjectStorage(dir);
+		await first.initialize();
+		await first.upload("vault/blob", streamOf("good"), 4);
+		writeFileSync(path.join(dir, ".uploads", "abandoned.part"), "partial");
+		const next = new LocalDiskBlobObjectStorage(dir);
+		await next.initialize();
+		expect(readdirSync(path.join(dir, ".uploads"))).toEqual([]);
+		expect(await new Response(await next.download("vault/blob")).text()).toBe("good");
+	});
+	it("keeps temporary files inside a symlinked storage root and reserves their namespace", async () => {
+		const root = mkdtempSync(path.join(tmpdir(), "synch-blob-link-"));
+		try {
+			const target = path.join(root, "target");
+			const link = path.join(root, "blobs");
+			mkdirSync(target);
+			symlinkSync(target, link, "dir");
+			const storage = new LocalDiskBlobObjectStorage(link);
+			await storage.initialize();
+			writeFileSync(path.join(target, ".uploads", "pending.part"), "partial");
+			await storage.upload("vault/blob", streamOf("good"), 4);
+			for (const key of [".uploads/pending.part", "./.uploads/pending.part", ""]) {
+				await expect(storage.download(key)).rejects.toThrow("reserved storage directory");
+				await expect(storage.deleteByPrefix(key)).rejects.toThrow("reserved storage directory");
+				await expect(storage.upload(key, streamOf("x"), 1)).rejects.toThrow("reserved storage directory");
+			}
+			await storage.deleteByPrefix("vault/");
+			expect(readFileSync(path.join(target, ".uploads", "pending.part"), "utf8")).toBe("partial");
+			expect(readdirSync(root).sort()).toEqual(["blobs", "target"]);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 });

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/local-disk-object-storage.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/local-disk-object-storage.ts
@@ -1,5 +1,6 @@
+import { randomUUID } from "node:crypto";
 import { createReadStream, createWriteStream } from "node:fs";
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, readdir, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
@@ -8,7 +9,23 @@ import type { BlobObjectStorage } from "../../application/ports/outbound/blob-ob
 import { limitBodySize } from "./body-size";
 
 export class LocalDiskBlobObjectStorage implements BlobObjectStorage {
+	private get uploadsDir(): string {
+		return path.join(path.resolve(this.baseDir), ".uploads");
+	}
+
 	constructor(private readonly baseDir: string) {}
+
+	/** Single-server storage: call before accepting requests, never during uploads.
+	 * Keep parts inside the blob directory so mount points and symlinks also
+	 * keep the final rename on the same filesystem. */
+	async initialize(): Promise<void> {
+		await mkdir(this.uploadsDir, { recursive: true });
+		for (const entry of await readdir(this.uploadsDir, { withFileTypes: true })) {
+			if (entry.isFile() && entry.name.endsWith(".part")) {
+				await rm(path.join(this.uploadsDir, entry.name));
+			}
+		}
+	}
 
 	async upload(
 		key: string,
@@ -17,25 +34,31 @@ export class LocalDiskBlobObjectStorage implements BlobObjectStorage {
 	): Promise<{ size: number; sizeMismatch: boolean }> {
 		const filePath = this.resolveKeyPath(key);
 		await mkdir(path.dirname(filePath), { recursive: true });
-		const limited = limitBodySize(body, declaredSizeBytes);
-		let uploadError: unknown;
+		await mkdir(this.uploadsDir, { recursive: true });
+		const temporaryPath = path.join(this.uploadsDir, `${randomUUID()}.part`);
+		let completed = false;
 		try {
-			await pipeline(
-				Readable.fromWeb(limited.readable as unknown as import("node:stream/web").ReadableStream),
-				createWriteStream(filePath),
-			);
-		} catch (error) {
-			uploadError = error;
+			const limited = limitBodySize(body, declaredSizeBytes);
+			const [writeResult, sizeResult] = await Promise.allSettled([
+				pipeline(
+					Readable.fromWeb(limited.readable as unknown as import("node:stream/web").ReadableStream),
+					createWriteStream(temporaryPath, { flags: "wx" }),
+				),
+				limited.sizeMismatch,
+			]);
+			if (sizeResult.status === "rejected") throw sizeResult.reason;
+			if (sizeResult.value) return { size: 0, sizeMismatch: true };
+			if (writeResult.status === "rejected") throw writeResult.reason;
+			await rename(temporaryPath, filePath);
+			completed = true;
+			return { size: declaredSizeBytes, sizeMismatch: false };
+		} finally {
+			if (!completed) {
+				await rm(temporaryPath, { force: true }).catch(() => {
+					console.warn("[blob-storage] incomplete upload cleanup failed", { key, temporaryPath });
+				});
+			}
 		}
-		const sizeMismatch = await limited.sizeMismatch;
-		if (sizeMismatch) {
-			return { size: 0, sizeMismatch: true };
-		}
-		if (uploadError) {
-			throw uploadError;
-		}
-		const size = (await stat(filePath)).size;
-		return { size, sizeMismatch: sizeMismatch || size !== declaredSizeBytes };
 	}
 
 	async download(key: string): Promise<ReadableStream<Uint8Array> | null> {
@@ -75,6 +98,9 @@ export class LocalDiskBlobObjectStorage implements BlobObjectStorage {
 		const resolved = path.resolve(resolvedBase, key);
 		if (resolved !== resolvedBase && !resolved.startsWith(resolvedBase + path.sep)) {
 			throw new Error(`blob key escapes storage base directory: ${key}`);
+		}
+		if (resolved === resolvedBase || path.relative(resolvedBase, resolved).split(path.sep)[0] === ".uploads") {
+			throw new Error("blob key targets reserved storage directory");
 		}
 		return resolved;
 	}

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/r2-object-storage.test.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/r2-object-storage.test.ts
@@ -35,6 +35,28 @@ describe("R2BlobObjectStorage", () => {
 		vi.unstubAllGlobals();
 	});
 
+	it("cancels input when R2 rejects before consuming the upload", async () => {
+		const error = new Error("R2 unavailable");
+		const cancel = vi.fn();
+		const storage = new R2BlobObjectStorage({ put: vi.fn(async () => { throw error; }) } as unknown as R2Bucket);
+		const body = new ReadableStream<Uint8Array>({
+			pull(controller) { controller.enqueue(new Uint8Array([1])); }, cancel,
+		});
+		await expect(storage.upload("vault/blob", body, 100)).rejects.toBe(error);
+		expect(cancel).toHaveBeenCalledWith(error);
+	});
+
+	it("propagates a failed source through the R2 consumer", async () => {
+		const error = new Error("client disconnected");
+		const storage = new R2BlobObjectStorage({
+			put: vi.fn(async (_key: string, body: ReadableStream<Uint8Array>) => {
+				await new Response(body).arrayBuffer();
+				return { size: 3 };
+			}),
+		} as unknown as R2Bucket);
+		await expect(storage.upload("vault/blob", new ReadableStream({ start(c) { c.error(error); } }), 3)).rejects.toBe(error);
+	});
+
 	it("deletes all objects under a prefix in R2 list batches", async () => {
 		const bucket = {
 			list: vi

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/r2-object-storage.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/r2-object-storage.ts
@@ -12,7 +12,12 @@ export class R2BlobObjectStorage implements BlobObjectStorage {
 	): Promise<{ size: number; sizeMismatch: boolean }> {
 		const fixed = new FixedLengthStream(declaredSizeBytes);
 		const [uploadResult, pipeResult] = await Promise.allSettled([
-			this.bucket.put(key, fixed.readable),
+			this.bucket.put(key, fixed.readable).catch(async (error: unknown) => {
+				// R2 can reject before it consumes the body (e.g. unavailable storage).
+				// Stop the producer even when the reader was never acquired by R2.
+				if (!fixed.readable.locked) await fixed.readable.cancel(error).catch(() => {});
+				throw error;
+			}),
 			body.pipeTo(fixed.writable),
 		]);
 		if (

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/s3-object-storage.test.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/s3-object-storage.test.ts
@@ -5,6 +5,17 @@ import { describe, expect, it, vi } from "vitest";
 import { S3BlobObjectStorage, s3DeleteResultErrorKeys } from "./s3-object-storage";
 
 describe("S3BlobObjectStorage", () => {
+	it("settles an interrupted input without issuing an S3 upload", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		try {
+			const storage = new S3BlobObjectStorage({ endpoint: "http://localhost:9000", bucket: "test", accessKeyId: "test", secretAccessKey: "test" });
+			const error = new Error("connection reset");
+			await expect(storage.upload("vault/blob", new ReadableStream({ start(c) { c.error(error); } }), 3)).rejects.toBe(error);
+			expect(fetchMock).not.toHaveBeenCalled();
+		} finally { vi.unstubAllGlobals(); }
+	});
+
 	it("rejects traversal keys before issuing a request", async () => {
 		const storage = new S3BlobObjectStorage({
 			endpoint: "http://localhost:9000",

--- a/apps/api/src/sync-blob-transfer/adapters/outbound/s3-object-storage.ts
+++ b/apps/api/src/sync-blob-transfer/adapters/outbound/s3-object-storage.ts
@@ -37,21 +37,14 @@ export class S3BlobObjectStorage implements BlobObjectStorage {
 		declaredSizeBytes: number,
 	): Promise<{ size: number; sizeMismatch: boolean }> {
 		const limited = limitBodySize(body, declaredSizeBytes);
-		let buffer: ArrayBuffer;
-		let readError: unknown;
-		try {
-			buffer = await new Response(limited.readable).arrayBuffer();
-		} catch (error) {
-			readError = error;
-			buffer = new ArrayBuffer(0);
-		}
-		const sizeMismatch = await limited.sizeMismatch;
-		if (sizeMismatch) {
-			return { size: buffer.byteLength, sizeMismatch: true };
-		}
-		if (readError) {
-			throw readError;
-		}
+		const [readResult, sizeResult] = await Promise.allSettled([
+			new Response(limited.readable).arrayBuffer(),
+			limited.sizeMismatch,
+		]);
+		if (sizeResult.status === "rejected") throw sizeResult.reason;
+		if (sizeResult.value) return { size: 0, sizeMismatch: true };
+		if (readResult.status === "rejected") throw readResult.reason;
+		const buffer = readResult.value;
 		const response = await this.client.fetch(this.objectUrl(key), {
 			method: "PUT",
 			body: buffer,
@@ -61,7 +54,7 @@ export class S3BlobObjectStorage implements BlobObjectStorage {
 				`s3 blob upload failed for ${key}: ${response.status} ${await response.text()}`,
 			);
 		}
-		return { size: buffer.byteLength, sizeMismatch: sizeMismatch || buffer.byteLength !== declaredSizeBytes };
+		return { size: buffer.byteLength, sizeMismatch: false };
 	}
 
 	async download(key: string): Promise<ReadableStream<Uint8Array> | null> {

--- a/apps/api/src/sync-blob-transfer/application/ports/outbound/coordinator-blob-stager.ts
+++ b/apps/api/src/sync-blob-transfer/application/ports/outbound/coordinator-blob-stager.ts
@@ -7,5 +7,5 @@ export type BlobStageInput = {
 
 export interface CoordinatorBlobStager {
 	stageBlob(input: BlobStageInput): Promise<void>;
-	abortStagedBlob(input: Pick<BlobStageInput, "vaultId" | "blobId" | "token">): Promise<void>;
+	abortStagedBlob(input: Pick<BlobStageInput, "vaultId" | "blobId">): Promise<void>;
 }

--- a/apps/api/src/sync-blob-transfer/application/services/blob-transfer-service.test.ts
+++ b/apps/api/src/sync-blob-transfer/application/services/blob-transfer-service.test.ts
@@ -57,7 +57,7 @@ describe("blob transfer use cases", () => {
 		expect(blobStorage.upload).toHaveBeenCalledWith("vault-1/blob-1", expect.anything(), 3);
 	});
 
-	it("deletes the object before aborting when the stored size mismatches", async () => {
+	it("leaves partial object cleanup to storage before aborting a size mismatch", async () => {
 		const blobStorage = storage({
 			upload: vi.fn(async () => ({ size: 2, sizeMismatch: true })),
 		});
@@ -77,7 +77,7 @@ describe("blob transfer use cases", () => {
 				body: body("abc"),
 			}),
 		).rejects.toMatchObject({ code: "size_mismatch" });
-		expect(blobStorage.delete).toHaveBeenCalledWith("vault-1/blob-1");
+		expect(blobStorage.delete).not.toHaveBeenCalled();
 		expect(stager.abortStagedBlob).toHaveBeenCalledTimes(1);
 	});
 
@@ -101,6 +101,16 @@ describe("blob transfer use cases", () => {
 			}),
 		).rejects.toBe(uploadError);
 		expect(stager.abortStagedBlob).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves the upload error when staged cleanup also fails", async () => {
+		const error = new Error("connection aborted");
+		const useCase = new BlobTransferService(
+			{ verifySyncToken: vi.fn(async () => ({}) as never) },
+			{ stageBlob: vi.fn(async () => {}), abortStagedBlob: vi.fn(async () => { throw new Error("expired token"); }) },
+			storage({ upload: vi.fn(async () => { throw error; }) }), objectKeyBuilder,
+		);
+		await expect(useCase.uploadBlob({ vaultId: "v", blobId: "b", declaredSizeBytes: 3, token: "t", body: body("abc") })).rejects.toBe(error);
 	});
 
 	it("verifies before touching storage and rejects unsafe ids", async () => {

--- a/apps/api/src/sync-blob-transfer/application/services/blob-transfer-service.ts
+++ b/apps/api/src/sync-blob-transfer/application/services/blob-transfer-service.ts
@@ -41,11 +41,7 @@ export class BlobTransferService implements UploadBlob, DownloadBlob {
 				input.declaredSizeBytes,
 			);
 		} catch (error) {
-			await this.coordinatorBlobStager.abortStagedBlob({
-				vaultId: input.vaultId,
-				blobId: input.blobId,
-				token: input.token,
-			});
+			await this.abortUpload(input);
 			throw error;
 		}
 
@@ -53,18 +49,28 @@ export class BlobTransferService implements UploadBlob, DownloadBlob {
 			uploaded.sizeMismatch ||
 			uploaded.size !== input.declaredSizeBytes
 		) {
-			await this.blobStorage.delete(objectKey).catch(() => {});
-			await this.coordinatorBlobStager.abortStagedBlob({
-				vaultId: input.vaultId,
-				blobId: input.blobId,
-				token: input.token,
-			});
+			await this.abortUpload(input);
 			throw new BlobTransferApplicationError("size_mismatch", {
 				declaredSizeBytes: input.declaredSizeBytes,
 			});
 		}
 
 		return { ok: true, blobId: input.blobId };
+	}
+
+	private async abortUpload(input: BlobUploadInput): Promise<void> {
+		try {
+			await this.coordinatorBlobStager.abortStagedBlob({
+				vaultId: input.vaultId,
+				blobId: input.blobId,
+			});
+		} catch {
+			// GC retains responsibility for leftover stages if the coordinator is
+			// unavailable. Never replace the original transfer error with cleanup.
+			console.warn("[blob-transfer] staged upload cleanup failed", {
+				vaultId: input.vaultId, blobId: input.blobId,
+			});
+		}
 	}
 
 	async downloadBlob(input: BlobDownloadInput): Promise<ReadableStream<Uint8Array> | null> {

--- a/apps/api/src/sync-blob-transfer/application/services/upload-cleanup.test.ts
+++ b/apps/api/src/sync-blob-transfer/application/services/upload-cleanup.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { LocalDiskBlobObjectStorage } from "../../adapters/outbound/local-disk-object-storage";
+import { BlobTransferService } from "./blob-transfer-service";
+import { BlobService } from "../../../sync-coordinator/application/services/blob-service";
+import { BlobGcService } from "../../../sync-coordinator/application/services/blob-gc-service";
+import {
+	createSqliteCoordinator,
+	closeAllTestSqliteCoordinators,
+} from "../../../sync-coordinator/adapters/outbound/sqlite/test-helpers";
+
+let directory: string | undefined;
+afterEach(() => {
+	vi.restoreAllMocks();
+	closeAllTestSqliteCoordinators();
+	if (directory) rmSync(directory, { recursive: true, force: true });
+});
+
+it("retains a completed object after a failed retry until GC removes its object and accounting together", async () => {
+	vi.spyOn(Date, "now").mockReturnValue(1_000);
+	const { unitOfWork, blobStore, healthStore } = await createSqliteCoordinator();
+	directory = mkdtempSync(path.join(tmpdir(), "synch-upload-cleanup-"));
+	const storage = new LocalDiskBlobObjectStorage(directory);
+	const keys = {
+		blobObjectKey: (vaultId: string, blobId: string) => `${vaultId}/${blobId}`,
+		blobObjectKeyPrefix: (vaultId: string) => `${vaultId}/`,
+	};
+	const health = { scheduleSummaryFlush: vi.fn(async () => {}), notifyStorageStatusChanged: vi.fn() };
+	const scheduler = { defer: vi.fn(async () => {}) };
+	const gc = new BlobGcService(unitOfWork.stores.state, unitOfWork, storage, keys, scheduler, health);
+	const verifier = { verifySyncToken: vi.fn(async () => ({
+		sub: "user", displayName: "User", vaultId: "vault-1", localVaultId: "device", scope: "vault:sync" as const, iat: 0, exp: 10_000,
+	})) };
+	const blobs = new BlobService(verifier, unitOfWork, gc, { closeAllSockets: vi.fn() }, storage, keys, 100, health);
+	const transfer = new BlobTransferService(verifier, {
+		stageBlob: (input) => blobs.stageBlob(input.token, input.vaultId, input.blobId, input.sizeBytes),
+		abortStagedBlob: (input) => blobs.abortStagedBlob(input.vaultId, input.blobId),
+	}, storage, keys);
+	const upload = (text: string) => transfer.uploadBlob({
+		vaultId: "vault-1", blobId: "blob", token: "token", declaredSizeBytes: 4,
+		body: new Response(text).body!,
+	});
+
+	await upload("good");
+	vi.mocked(Date.now).mockReturnValue(1_010);
+	await expect(upload("bad")).rejects.toMatchObject({ code: "size_mismatch" });
+	expect(await new Response(await storage.download("vault-1/blob")).text()).toBe("good");
+	expect(blobStore.readBlob("blob")).toMatchObject({ state: "staged", delete_after: 1_110 });
+	expect(healthStore.readStorageStatus().storageUsedBytes).toBe(4);
+	expect(scheduler.defer).toHaveBeenLastCalledWith("blob_gc", 1_110, 1_010);
+
+	await gc.runGc("vault-1", { now: 1_109 });
+	expect(await storage.exists("vault-1/blob")).toBe(true);
+	await gc.runGc("vault-1", { now: 1_110 });
+	expect(await storage.exists("vault-1/blob")).toBe(false);
+	expect(blobStore.readBlob("blob")).toBeNull();
+	expect(healthStore.readStorageStatus().storageUsedBytes).toBe(0);
+});

--- a/apps/api/src/sync-coordinator/adapters/inbound/durable-object-rpc/sync-coordinator.ts
+++ b/apps/api/src/sync-coordinator/adapters/inbound/durable-object-rpc/sync-coordinator.ts
@@ -322,7 +322,7 @@ function formatRequestForLog(request: Request): { method: string; path: string }
 function mapCoordinatorRpcError(error: unknown): unknown {
 	if (!(error instanceof SyncCoordinatorApplicationError)) return error;
 	if (error.code === "sync_paused") {
-		return apiError(403, "forbidden", "vault sync is temporarily paused for repair");
+		return apiError(503, "sync_paused", "vault sync is temporarily paused for repair");
 	}
 	return apiError(
 		rpcErrorStatus(error.code),

--- a/apps/api/src/sync-coordinator/adapters/inbound/http/error-mapper.ts
+++ b/apps/api/src/sync-coordinator/adapters/inbound/http/error-mapper.ts
@@ -17,8 +17,8 @@ export function mapSyncCoordinatorApplicationError(error: unknown): Response | u
 	if (!(error instanceof SyncCoordinatorApplicationError)) return undefined;
 	if (error.code === "sync_paused") {
 		return response(
-			{ error: "forbidden", message: "vault sync is temporarily paused for repair" },
-			403,
+			{ error: "sync_paused", message: "vault sync is temporarily paused for repair" },
+			503,
 		);
 	}
 	if (error.code === "not_found") {

--- a/apps/api/src/sync-coordinator/adapters/inbound/http/routes.ts
+++ b/apps/api/src/sync-coordinator/adapters/inbound/http/routes.ts
@@ -18,7 +18,7 @@ export interface CoordinatorHttpServices {
 		blobId: string,
 		sizeBytes: number,
 	): Promise<void>;
-	abortStagedBlob(token: string | null, vaultId: string, blobId: string): Promise<void>;
+	abortStagedBlob(vaultId: string, blobId: string): Promise<void>;
 	applyVaultPolicy(
 		vaultId: string,
 		limits: VaultStateLimits,
@@ -111,7 +111,7 @@ export function createCoordinatorApp(
 		),
 		async (c) => {
 			const { vaultId, blobId } = c.req.valid("param");
-			await deps.services.abortStagedBlob(readSyncToken(c.req.raw), vaultId, blobId);
+			await deps.services.abortStagedBlob(vaultId, blobId);
 			return new Response(null, { status: 204 });
 		},
 	);

--- a/apps/api/src/sync-coordinator/adapters/outbound/sqlite/blob-store.test.ts
+++ b/apps/api/src/sync-coordinator/adapters/outbound/sqlite/blob-store.test.ts
@@ -35,7 +35,7 @@ describe("sqlite backend: blob staging", () => {
 		expect(healthStore.readStorageStatus().storageUsedBytes).toBe(1_000);
 	});
 
-	it("atomically pauses sync when a stale staged blob is retried", async () => {
+	it("retries an unreferenced stale stage without pausing or changing its creation time", async () => {
 		const { unitOfWork, blobStore, cursorStore } =
 			await createSqliteCoordinator();
 		await stage(unitOfWork, "blob-stale", 1_000, 100, 200);
@@ -44,16 +44,13 @@ describe("sqlite backend: blob staging", () => {
 		await expect(
 			stage(unitOfWork, "blob-stale", 1_000, retriedAt, retriedAt + 100),
 		).resolves.toEqual({
-			status: "sync_paused",
+			status: "staged",
 		});
-		expect(cursorStore.readSyncPause()).toMatchObject({
-			pausedAt: retriedAt,
-			reason: expect.stringContaining("blob-stale"),
-		});
+		expect(cursorStore.readSyncPause()).toBeNull();
 		expect(blobStore.readBlob("blob-stale")).toMatchObject({
 			created_at: 100,
-			last_uploaded_at: 100,
-			delete_after: 200,
+			last_uploaded_at: retriedAt,
+			delete_after: retriedAt + 100,
 		});
 	});
 

--- a/apps/api/src/sync-coordinator/application/services/bind-coordinator-api.ts
+++ b/apps/api/src/sync-coordinator/application/services/bind-coordinator-api.ts
@@ -24,11 +24,7 @@ export type CoordinatorApi = CoordinatorApplicationPort & {
 		blobId: string,
 		sizeBytes: number,
 	): Promise<void>;
-	abortStagedBlob(
-		token: string | null | undefined,
-		vaultId: string,
-		blobId: string,
-	): Promise<void>;
+	abortStagedBlob(vaultId: string, blobId: string): Promise<void>;
 	deleteBlob(
 		token: string | null | undefined,
 		vaultId: string,
@@ -74,8 +70,8 @@ export function bindCoordinatorApi(services: CoordinatorApiServices): Coordinato
 			services.entryService.purgeDeletedEntries(session, message),
 		stageBlob: (token, vaultId, blobId, sizeBytes) =>
 			services.blobService.stageBlob(token, vaultId, blobId, sizeBytes),
-		abortStagedBlob: (token, vaultId, blobId) =>
-			services.blobService.abortStagedBlob(token, vaultId, blobId),
+		abortStagedBlob: (vaultId, blobId) =>
+			services.blobService.abortStagedBlob(vaultId, blobId),
 		deleteBlob: (token, vaultId, blobId) =>
 			services.blobService.deleteBlob(token, vaultId, blobId),
 		applyVaultPolicy: (vaultId, limits) =>

--- a/apps/api/src/sync-coordinator/application/services/blob-record-operations.ts
+++ b/apps/api/src/sync-coordinator/application/services/blob-record-operations.ts
@@ -21,6 +21,8 @@ export function stageBlobRecord(
 	now: number,
 	deleteAfter: number,
 ) {
+	const pause = stores.state.readSyncPause();
+	if (pause) return { kind: "sync_paused", reason: pause.reason } as const;
 	const blob = stores.blobs.readBlob(blobId);
 	if (!stores.state.readVaultId()) {
 		throw new SyncCoordinatorApplicationError("sync_state_uninitialized", {

--- a/apps/api/src/sync-coordinator/application/services/blob-service.test.ts
+++ b/apps/api/src/sync-coordinator/application/services/blob-service.test.ts
@@ -69,7 +69,7 @@ describe("coordinator blob lifecycle", () => {
 		}
 	});
 
-	it("quarantines a vault when a stale staged blob is retried", async () => {
+	it("quarantines a referenced stale staged blob", async () => {
 		const syncTokenService = {
 			verifySyncToken: vi.fn(async () => ({
 				sub: "user-1",
@@ -91,6 +91,7 @@ describe("coordinator blob lifecycle", () => {
 				delete_after: 1,
 			})),
 			pauseSync,
+			read: vi.fn(() => ({ hasCurrentReference: true, hasRetainedHistory: false })),
 		});
 		const socketService = socketServiceMock();
 		const service = createCoordinatorService({
@@ -108,9 +109,32 @@ describe("coordinator blob lifecycle", () => {
 			expect.stringContaining("blob-stale"),
 		);
 		expect(socketService.closeAllSockets).toHaveBeenCalledWith(
-			4403,
+			1013,
 			"sync paused for vault repair",
 		);
+	});
+
+	it("refuses new stages while a repair pause is active", async () => {
+		const stateRepository = createTestCoordinatorState({
+			readSyncPause: vi.fn(() => ({ pausedAt: 1, reason: "repair in progress" })),
+		});
+		const service = createCoordinatorService({ stateRepository });
+		await expect(service.stageBlob("token", "vault-1", "new-blob", 3))
+			.rejects.toMatchObject({ code: "sync_paused" });
+		expect(stateRepository.persistStage).not.toHaveBeenCalled();
+	});
+
+	it("retains an authenticated upload for GC even after its client token expires", async () => {
+		const verifySyncToken = vi.fn(async () => { throw new Error("expired token"); });
+		const stateRepository = createTestCoordinatorState({
+			readBlob: vi.fn(() => ({ blob_id: "blob", state: "staged" as const, size_bytes: 3, created_at: 1, last_uploaded_at: 1, delete_after: 100 })),
+		});
+		const service = createCoordinatorService({ stateRepository, syncTokenService: { verifySyncToken } as unknown as SyncTokenVerifier });
+		await service.abortStagedBlob("vault-1", "blob");
+		expect(verifySyncToken).not.toHaveBeenCalled();
+		expect(stateRepository.deleteBlobRecord).not.toHaveBeenCalled();
+		expect(stateRepository.adjustStorageUsedBytes).not.toHaveBeenCalled();
+		await expect(service.abortStagedBlob("other-vault", "blob")).rejects.toMatchObject({ code: "vault_mismatch" });
 	});
 
 	it("skips explicit blob deletion when the blob is still referenced", async () => {
@@ -192,7 +216,7 @@ describe("coordinator blob lifecycle", () => {
 			stateRepository,
 		});
 
-		await service.abortStagedBlob("token", "vault-1", "blob-1");
+		await service.abortStagedBlob("vault-1", "blob-1");
 
 		expect(deleteStagedBlob).not.toHaveBeenCalled();
 	});

--- a/apps/api/src/sync-coordinator/application/services/blob-service.ts
+++ b/apps/api/src/sync-coordinator/application/services/blob-service.ts
@@ -4,7 +4,6 @@ import { isBlobPinned } from "../../domain/blob-gc-policy";
 import {
 	stageBlobRecord,
 	accountForDeletedBlobs,
-	deleteUnreferencedStagedBlob,
 } from "./blob-record-operations";
 import type {
 	BlobObjectKeyBuilder,
@@ -54,7 +53,7 @@ export class BlobService {
 		if (decision.kind === "rejected") throwBlobStageError(blobId, decision);
 
 		if (decision.kind === "sync_paused") {
-			this.socketService.closeAllSockets(4403, "sync paused for vault repair");
+			this.socketService.closeAllSockets(1013, "sync paused for vault repair");
 			throw syncPausedError();
 		}
 
@@ -62,18 +61,20 @@ export class BlobService {
 		this.healthService.notifyStorageStatusChanged();
 	}
 
-	async abortStagedBlob(
-		token: string | null | undefined,
-		vaultId: string,
-		blobId: string,
-	): Promise<void> {
-		await this.syncTokenService.verifySyncToken(token, vaultId);
-		const now = Date.now();
-		this.unitOfWork.run((stores) =>
-			deleteUnreferencedStagedBlob(stores, blobId, now),
-		);
-		await this.healthService.scheduleSummaryFlush();
-		this.healthService.notifyStorageStatusChanged();
+	/** Internal compensation for an already authenticated upload. Revalidating the
+	 * client's short-lived token here would prevent cleanup after slow transfers. */
+	async abortStagedBlob(vaultId: string, blobId: string): Promise<void> {
+		if (this.unitOfWork.stores.state.readVaultId() !== vaultId) {
+			throw new SyncCoordinatorApplicationError("vault_mismatch");
+		}
+		// Another attempt may already have stored this object or still be uploading.
+		// Keep its row, quota reservation, and grace deadline until GC can delete
+		// the unreferenced object and its record together.
+		const blob = this.unitOfWork.stores.blobs.readBlob(blobId);
+		if (blob?.state === "staged" && blob.delete_after !== null) {
+			const now = Date.now();
+			await this.blobGcService.scheduleAt(Math.max(now, blob.delete_after), now);
+		}
 	}
 
 	async deleteBlob(

--- a/apps/api/src/sync-coordinator/domain/blob-policy.test.ts
+++ b/apps/api/src/sync-coordinator/domain/blob-policy.test.ts
@@ -15,9 +15,10 @@ const baseInput = {
 };
 
 describe("decideBlobStage", () => {
-	it("pauses sync for a stale staged blob before other checks", () => {
+	it("pauses sync when a stale staged blob is still referenced", () => {
 		const decision = decideBlobStage({
 			...baseInput,
+			isPinned: true,
 			existing: { state: "staged", sizeBytes: 100, createdAt: 1 },
 		});
 
@@ -25,6 +26,11 @@ describe("decideBlobStage", () => {
 			kind: "sync_paused",
 			reason: "staged blob blob-1 remained staged for at least one hour",
 		});
+	});
+
+	it("allows retrying an old unreferenced upload without double charging or pausing", () => {
+		expect(decideBlobStage({ ...baseInput, existing: { state: "staged", sizeBytes: 100, createdAt: 1 } }))
+			.toEqual({ kind: "staged", storageDeltaBytes: 0 });
 	});
 
 	it("rejects a file over the configured maximum", () => {

--- a/apps/api/src/sync-coordinator/domain/blob-policy.ts
+++ b/apps/api/src/sync-coordinator/domain/blob-policy.ts
@@ -46,6 +46,9 @@ export function decideBlobStage(input: {
 	maxFileSizeBytes: number;
 }): BlobStageDecision {
 	if (
+		// An unreferenced staged object is an unfinished upload, not evidence of
+		// vault corruption. It can be retried without deleting any shared object.
+		input.isPinned &&
 		input.existing?.state === "staged" &&
 		input.now - input.existing.createdAt >= input.staleAfterMs
 	) {

--- a/apps/api/test/integration/sync-do/repair.test.ts
+++ b/apps/api/test/integration/sync-do/repair.test.ts
@@ -35,6 +35,14 @@ describe("admin sync repair integration", () => {
 			);
 		});
 
+		const pausedToken = await apiRequest("/v1/sync/token", {
+			method: "POST",
+			headers: { cookie: primary.sessionCookie, "content-type": "application/json" },
+			body: JSON.stringify({ vaultId: primary.vaultId, localVaultId: "repair-device" }),
+		});
+		expect(pausedToken.status).toBe(503);
+		await expect(pausedToken.json()).resolves.toMatchObject({ error: "sync_paused" });
+
 		const repaired = await adminRepairRequest(primary.vaultId);
 		const body = (await repaired.json()) as {
 			status: string;
@@ -67,6 +75,13 @@ describe("admin sync repair integration", () => {
 		}));
 		expect(state.pause).toBeNull();
 		expect(state.blob).toBeUndefined();
+		const renewed = await issueSyncToken(primary.sessionCookie, primary.vaultId, "repair-device");
+		await uploadBlob(primary.vaultId, renewed.token, blobId, "retry after repair");
+		const downloaded = await apiRequest(`/v1/vaults/${primary.vaultId}/blobs/${blobId}`, {
+			headers: { authorization: `Bearer ${renewed.token}` },
+		});
+		expect(await downloaded.text()).toBe("retry after repair");
+
 	});
 });
 

--- a/apps/api/test/self-host/e2e.test.ts
+++ b/apps/api/test/self-host/e2e.test.ts
@@ -1,7 +1,8 @@
 import { serve, type ServerType } from "@hono/node-server";
 import { type ChildProcess, spawn } from "node:child_process";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { createServer } from "node:net";
+import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -129,7 +130,7 @@ async function waitForHealth(baseUrl: string, deadline = Date.now() + 10_000): P
  * uncheckpointed `-wal` file behind, which is the actual crash-recovery path
  * `locking_mode = EXCLUSIVE` + WAL replay needs to be exercised against.
  */
-async function bootSubprocessServer(dataDir: string): Promise<{ baseUrl: string; child: ChildProcess }> {
+async function bootSubprocessServer(dataDir: string, extraEnv: Record<string, string> = {}): Promise<{ baseUrl: string; child: ChildProcess }> {
 	const port = await reserveFreePort();
 	const baseUrl = `http://127.0.0.1:${port}`;
 	// `detached: true` makes this child the leader of its own process group.
@@ -148,6 +149,7 @@ async function bootSubprocessServer(dataDir: string): Promise<{ baseUrl: string;
 			BETTER_AUTH_SECRET: "test-secret-test-secret-test-secret",
 			AUTH_ALLOWED_EMAILS: SELF_HOST_ALLOWED_EMAIL,
 			SYNC_TOKEN_SECRET: "test-sync-token-secret-test-sync",
+			...extraEnv,
 		},
 		stdio: ["ignore", "pipe", "pipe"],
 		detached: true,
@@ -283,6 +285,95 @@ describe("self-hosted Node runtime: end-to-end sync", () => {
 		}
 		cleanup = [];
 	});
+
+	it("cleans orphaned upload parts before serving after a process crash", async () => {
+		const dataDir = mkdtempSync(path.join(tmpdir(), "synch-orphan-upload-"));
+		cleanup.push(() => rmSync(dataDir, { recursive: true, force: true }));
+		const first = await bootSubprocessServer(dataDir);
+		cleanup.push(() => killAndWaitForExit(first.child));
+		const blobDir = path.join(dataDir, "blobs");
+		mkdirSync(path.join(blobDir, "vault"), { recursive: true });
+		writeFileSync(path.join(blobDir, "vault", "complete"), "good");
+		writeFileSync(path.join(blobDir, ".uploads", "interrupted.part"), "partial");
+		await killAndWaitForExit(first.child);
+		const second = await bootSubprocessServer(dataDir);
+		cleanup.push(() => killAndWaitForExit(second.child));
+		expect(readdirSync(path.join(blobDir, ".uploads")).filter(name => name.endsWith(".part"))).toEqual([]);
+		expect(readFileSync(path.join(blobDir, "vault", "complete"), "utf8")).toBe("good");
+	});
+
+	it.each(["timeout", "disconnect"] as const)("survives five concurrent upload failures (%s), then retries after restart", async (mode) => {
+		const dataDir = mkdtempSync(path.join(tmpdir(), "synch-interrupted-upload-"));
+		cleanup.push(() => rmSync(dataDir, { recursive: true, force: true }));
+		const first = await bootSubprocessServer(dataDir, { REQUEST_TIMEOUT_MS: "2000", SYNC_TOKEN_TTL_SECONDS: "2" });
+		cleanup.push(() => killAndWaitForExit(first.child));
+		const { sessionCookie, vaultId } = await signUpAndCreateVault(first.baseUrl);
+		const token = await issueSyncToken(first.baseUrl, sessionCookie, vaultId, "device-a");
+		const device = await connectSocket(first.baseUrl, vaultId, token);
+		cleanup.push(() => device.close());
+		device.send(JSON.stringify({ type: "hello", requestId: "hello", lastKnownCursor: 0 }));
+		await nextMessage(device, (m) => m.type === "hello_ack");
+		// Internal compensation and administrator repair stay private in self-hosting.
+		expect((await fetch(`${first.baseUrl}/internal/v1/vaults/${vaultId}/blobs/interrupted-0/stage`, { method: "DELETE" })).status).toBe(404);
+		expect((await fetch(`${first.baseUrl}/admin/v1/vaults/${vaultId}/sync-repair`, { method: "POST" })).status).toBe(404);
+		const sizes = [6, 10, 11, 11, 16].map((mb) => mb * 1024 * 1024);
+		const responses = await Promise.all(sizes.map((size, i) => new Promise<number | null>((resolve, reject) => {
+			const req = httpRequest(`${first.baseUrl}/v1/vaults/${vaultId}/blobs/interrupted-${i}`, {
+				method: "PUT", headers: { authorization: `Bearer ${token}`, "content-length": size, "x-blob-size": size },
+			}, (res) => {
+				res.resume();
+				res.on("end", () => resolve(res.statusCode!));
+			});
+			const timer = setInterval(() => req.write(Buffer.alloc(1024)), 50);
+			const disconnectTimer = mode === "disconnect" ? setTimeout(() => req.destroy(), 200) : undefined;
+			req.on("error", (error: NodeJS.ErrnoException) => {
+				if (mode === "disconnect") resolve(null);
+				else if (error.code !== "ECONNRESET") reject(error);
+			});
+			req.on("close", () => { clearInterval(timer); clearTimeout(disconnectTimer); });
+		})));
+		expect(responses).toEqual(sizes.map(() => mode === "timeout" ? 408 : null));
+		await waitForHealth(first.baseUrl);
+		expect(first.child.exitCode).toBeNull();
+		// The failed attempts must remove incomplete files before restart.
+		await expect.poll(() => listPublicFiles(path.join(dataDir, "blobs"))).toEqual([]);
+		await expect.poll(() => readdirSync(path.join(dataDir, "blobs", ".uploads"))).toEqual([]);
+		// Failed uploads retain their quota reservation until staged-blob GC.
+		const observerToken = await issueSyncToken(first.baseUrl, sessionCookie, vaultId, "observer");
+		const observer = await connectSocket(first.baseUrl, vaultId, observerToken);
+		cleanup.push(() => observer.close());
+		observer.send(JSON.stringify({ type: "hello", requestId: "observer-hello", lastKnownCursor: 0 }));
+		expect(await nextMessage(observer, (m) => m.type === "hello_ack"))
+			.toMatchObject({ storageStatus: { storageUsedBytes: sizes.reduce((sum, size) => sum + size, 0) } });
+		await killAndWaitForExit(first.child);
+		const second = await bootSubprocessServer(dataDir);
+		cleanup.push(() => killAndWaitForExit(second.child));
+		const retryToken = await issueSyncToken(second.baseUrl, sessionCookie, vaultId, "device-a");
+		// Retry the same blob IDs with complete bodies, in parallel, at a bounded rate.
+		await Promise.all(sizes.map(async (size, i) => {
+			const payload = Buffer.alloc(size, i + 1);
+			const url = `${second.baseUrl}/v1/vaults/${vaultId}/blobs/interrupted-${i}`;
+			await new Promise<void>((resolve, reject) => {
+				const req = httpRequest(url, { method: "PUT", headers: { authorization: `Bearer ${retryToken}`, "x-blob-size": size, "content-length": size } }, res => {
+					res.resume();
+					res.on("end", () => res.statusCode === 201 ? resolve() : reject(new Error(`upload status ${res.statusCode}`)));
+				});
+				let offset = 0;
+				const timer = setInterval(() => {
+					if (req.writableNeedDrain) return;
+					const end = Math.min(offset + 256 * 1024, size);
+					req.write(payload.subarray(offset, end));
+					offset = end;
+					if (offset === size) { clearInterval(timer); req.end(); }
+				}, 10);
+				req.on("error", reject);
+				req.on("close", () => clearInterval(timer));
+			});
+			const downloaded = await fetch(url, { headers: { authorization: `Bearer ${retryToken}` } });
+			expect(downloaded.status).toBe(200);
+			expect(Buffer.from(await downloaded.arrayBuffer()).equals(payload)).toBe(true);
+		}));
+	}, 40_000);
 
 	it("serves the auth pages Cloudflare would otherwise serve via its assets binding", async () => {
 		// On Cloudflare, wrangler.jsonc's "assets" binding serves apps/api/public/*

--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -9,3 +9,6 @@
 - Show a clear "checking for changes" status while the vault is being reconciled.
 
 ## Fixed
+
+- Preserve the original HTTP error when an upload fails with an empty or non-JSON response.
+- Keep the vault connected when the server temporarily pauses sync for repair.

--- a/apps/obsidian-plugin/src/adapters/http.test.ts
+++ b/apps/obsidian-plugin/src/adapters/http.test.ts
@@ -50,6 +50,23 @@ describe("ObsidianHttpClient", () => {
     });
   });
 
+  it.each([[408, ""], [413, "<html>too large</html>"], [502, "bad gateway"]])(
+    "preserves HTTP %i with a non-JSON error body", async (status, body) => {
+      setRequestUrlMock(async () => ({ status, get json() { return JSON.parse(body); } }));
+      const response = await defaultHttpClient.request({ url: "http://localhost/blob" });
+      expect(response.status).toBe(status);
+      expect(response.json).toBeUndefined();
+    },
+  );
+
+  it("leaves successful JSON parsing strict and binary responses lazy", async () => {
+    const bytes = new Uint8Array([1, 2, 3]).buffer;
+    setRequestUrlMock(async () => ({ status: 200, arrayBuffer: bytes, get json() { throw new SyntaxError("invalid JSON"); } }));
+    const response = await defaultHttpClient.request({ url: "http://localhost/blob" });
+    expect(response.arrayBuffer).toBe(bytes);
+    expect(() => response.json).toThrow(SyntaxError);
+  });
+
   it("defaults the method to GET", async () => {
     let capturedRequest: Record<string, unknown> | null = null;
     setRequestUrlMock(async (input) => {

--- a/apps/obsidian-plugin/src/adapters/http.ts
+++ b/apps/obsidian-plugin/src/adapters/http.ts
@@ -19,13 +19,25 @@ export {
 
 export class ObsidianHttpClient implements HttpClient {
   async request(input: HttpRequestInput): Promise<HttpResponseLike> {
-    return (await requestUrl({
+    const response = await requestUrl({
       url: input.url,
       method: input.method ?? "GET",
       throw: false,
       headers: input.headers,
       body: input.body,
-    }));
+    });
+    return {
+      status: response.status,
+      get arrayBuffer() { return response.arrayBuffer; },
+      get text() { return response.text; },
+      get json(): unknown {
+        // Obsidian parses lazily and throws even when requestUrl uses throw:false.
+        // Keep non-JSON error bodies from hiding the HTTP status. Successful JSON
+        // responses remain strict, and binary responses are never eagerly parsed.
+        if (response.status >= 200 && response.status < 300) return response.json as unknown;
+        try { return response.json as unknown; } catch { return undefined; }
+      },
+    };
   }
 }
 

--- a/packages/sync-client/src/remote-vault/unavailable.ts
+++ b/packages/sync-client/src/remote-vault/unavailable.ts
@@ -22,6 +22,13 @@ export function remoteVaultUnavailableFromApiError(
     return null;
   }
 
+  // Older servers used a generic 403 for repair pauses. Preserve the link to
+  // the vault so a temporary server condition cannot disconnect local state.
+  if (error.code === "sync_paused" ||
+      (error.code === "forbidden" && error.message === "vault sync is temporarily paused for repair")) {
+    return null;
+  }
+
   if (error.status === 404 || error.code === "not_found") {
     return new RemoteVaultUnavailableError(
       remoteVaultId,
@@ -47,7 +54,7 @@ export function remoteVaultUnavailableFromWebSocketClose(
   event: { code: number; reason: string },
   remoteVaultId: string,
 ): RemoteVaultUnavailableError | null {
-  if (event.code !== 4403) {
+  if (event.code !== 4403 || event.reason === "sync paused for vault repair") {
     return null;
   }
 

--- a/packages/sync-client/src/sync/diagnostics/format.ts
+++ b/packages/sync-client/src/sync/diagnostics/format.ts
@@ -41,6 +41,7 @@ const SAFE_ERROR_CODES = new Set([
   "quota_exceeded",
   "restore_commit_pending",
   "size_mismatch",
+  "sync_paused",
   "stale_revision",
   "unauthorized",
   "unavailable",

--- a/packages/sync-client/src/sync/engine/__tests__/auto-sync/retry-flow.test.ts
+++ b/packages/sync-client/src/sync/engine/__tests__/auto-sync/retry-flow.test.ts
@@ -221,6 +221,40 @@ describe("SyncAutoLoop retry flow", () => {
     await store.close();
   });
 
+  it.each([1013, 4403])("retains the vault and reconnects after a repair pause (%i)", async (code) => {
+    vi.useFakeTimers();
+
+    const store = createTestSyncStore();
+    const callbacks: SyncRealtimeCallbacks[] = [];
+    const onRemoteVaultUnavailable = vi.fn();
+    const autoLoop = new SyncAutoLoop({
+      getApiBaseUrl: () => "http://127.0.0.1:8787",
+      getSyncToken: async () => createToken(),
+      getSyncStore: () => store,
+      pushPendingMutations: vi.fn(async () => createPushResult()),
+      pullOnce: vi.fn(async () => {}),
+      realtimeClient: createRealtimeClient((nextCallbacks) => {
+        callbacks.push(nextCallbacks);
+      }),
+      reconnectDelayMs: 1_000,
+      onRemoteVaultUnavailable,
+    });
+
+    await autoLoop.start();
+
+    callbacks[0]?.onClose({
+      code,
+      reason: "sync paused for vault repair",
+    });
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    expect(callbacks).toHaveLength(2);
+    expect(onRemoteVaultUnavailable).not.toHaveBeenCalled();
+
+    autoLoop.stop();
+    await store.close();
+  });
+
   it("reconnects without reporting a realtime connection error", async () => {
     vi.useFakeTimers();
 

--- a/packages/sync-client/src/sync/remote/__tests__/realtime-client/connection.test.ts
+++ b/packages/sync-client/src/sync/remote/__tests__/realtime-client/connection.test.ts
@@ -11,6 +11,14 @@ import {
 } from "./helpers";
 
 describe("SyncRealtimeClient connection health", () => {
+  it.each([1013, 4403])("reports repair pauses over websocket (%i)", async (code) => {
+    const onError = vi.fn();
+    const { socket, session } = await openRealtimeSession({ callbacks: { onError } });
+    socket.emit("close", { code, reason: "sync paused for vault repair" });
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: "sync_paused" }));
+    session.close();
+  });
+
   it("exposes the server storage and file size policy from hello acknowledgement", async () => {
     const { session } = await openRealtimeSession();
 

--- a/packages/sync-client/src/sync/remote/client.test.ts
+++ b/packages/sync-client/src/sync/remote/client.test.ts
@@ -49,6 +49,14 @@ describe("SyncAccessClient", () => {
     });
   });
 
+  it.each([[503, "sync_paused"], [403, "forbidden"]])("preserves the vault link on a repair pause (%i)", async (status, code) => {
+    const client = new SyncAccessClient(createMockHttpClient(async () => ({
+      status, json: { error: code, message: "vault sync is temporarily paused for repair" },
+    })));
+    await expect(client.issueSyncToken("http://localhost", "token", { vaultId: "v", localVaultId: "l" }))
+      .rejects.toMatchObject({ name: "ApiRequestError", status, code });
+  });
+
   it("maps forbidden issuance failures to an access-denied vault error", async () => {
     const httpClient = createMockHttpClient(async () => ({
       status: 403,

--- a/packages/sync-client/src/sync/remote/realtime-socket-session.ts
+++ b/packages/sync-client/src/sync/remote/realtime-socket-session.ts
@@ -490,6 +490,10 @@ function syncRealtimeErrorFromCloseEvent(event: {
   code: number;
   reason: string;
 }): SyncRealtimeError | null {
+  if ((event.code === 1013 || event.code === 4403) &&
+      event.reason === "sync paused for vault repair") {
+    return new SyncRealtimeError("sync_paused", "vault sync is temporarily paused for repair");
+  }
   if (event.code !== 4409) {
     return null;
   }


### PR DESCRIPTION
Interrupted uploads can leave incomplete files or lose their original HTTP error, and a temporary repair pause can disconnect the plugin from its vault. This change makes failed uploads settle and clean up safely, preserves completed blobs during overlapping retries, and keeps repair pauses retryable without unlinking the vault.

- Write disk uploads to temporary files and rename only after size validation; clean abandoned parts at startup and retain staged quota reservations until GC.
- Propagate stream failures and cancellation, preserve the original transfer error during compensation, and add a configurable Node request timeout.
- Return `503 sync_paused`, recognize legacy repair-pause responses, and preserve HTTP status when Obsidian receives a non-JSON error body.
- Add regression coverage and update the Obsidian release notes.

Refs #38.

Validation: 63 focused API tests, all 337 sync-client tests, and 6 Obsidian HTTP adapter tests passed. The full API unit suite stalled without results and was stopped. The added Node end-to-end and Cloudflare integration tests were not run during this review.
