### PR TITLE
Add adaptive blob transfer concurrency

### DIFF
--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+- Automatically adjust simultaneous uploads and downloads based on observed transfer performance and server overload.
+
 - Require encrypted sync and conflict recovery checks before publishing plugin releases.
 - Reduce repeated encryption work when retrying uploads after an interrupted sync.
 - Show a clear "checking for changes" status while the vault is being reconciled.

--- a/packages/sync-client/src/sync/engine/pull-service.ts
+++ b/packages/sync-client/src/sync/engine/pull-service.ts
@@ -17,6 +17,9 @@ import {
 
 const DEFAULT_PULL_BATCH = 100;
 const DEFAULT_PULL_APPLY_WINDOW = 100;
+// TODO: Replace this fixed preparation cap with CPU and memory budgets, including
+// downloaded payloads waiting for apply. TransferScheduler controls network
+// concurrency separately; keep this cap until preparation is resource-bounded.
 const DEFAULT_PULL_PREPARE_CONCURRENCY = 10;
 
 export interface SyncPullServiceDeps extends SyncContentRuntimeDeps {

--- a/packages/sync-client/src/sync/engine/push-service.ts
+++ b/packages/sync-client/src/sync/engine/push-service.ts
@@ -33,6 +33,9 @@ import {
 } from "./push-mutation-committer";
 import { PushBlobRetryCache } from "./push-blob-retry-cache";
 
+// TODO: Replace this fixed preparation cap with CPU and memory budgets, including
+// prepared payloads waiting for transfer. TransferScheduler controls network
+// concurrency separately; keep this cap until preparation is resource-bounded.
 const DEFAULT_PUSH_PREPARE_CONCURRENCY = 12;
 
 export interface SyncPushServiceDeps extends SyncContentRuntimeDeps {

--- a/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.test.ts
+++ b/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { AdaptiveConcurrencyPolicy } from "./adaptive-concurrency-policy";
+
+const window = (bytes: number, meanDurationMs = 500) => ({ bytes, elapsedMs: 2_000, meanDurationMs });
+
+describe("AdaptiveConcurrencyPolicy", () => {
+  it("backs off on sustained throughput loss and latency growth even at the ceiling", () => {
+    const policy = new AdaptiveConcurrencyPolicy(2);
+    policy.observe(window(1_000), 2_000);
+    policy.observe(window(500, 1_000), 4_000);
+    expect(policy.limit).toBe(2);
+    policy.observe(window(500, 1_000), 6_000);
+    expect(policy.limit).toBe(1);
+  });
+  it("keeps a probe only if throughput improves without excessive latency", () => {
+    const policy = new AdaptiveConcurrencyPolicy();
+    policy.observe(window(1_000), 2_000);
+    expect(policy.limit).toBe(3);
+    policy.observe(window(1_300), 4_000);
+    expect(policy.limit).toBe(3);
+    policy.observe(window(1_300), 6_000);
+    expect(policy.limit).toBe(3);
+    policy.observe(window(1_300), 14_000);
+    expect(policy.limit).toBe(4);
+    policy.observe(window(1_800, 1_100), 16_000);
+    expect(policy.limit).toBe(3);
+  });
+
+  it("rolls back a plateau and retries after cooldown", () => {
+    const policy = new AdaptiveConcurrencyPolicy();
+    policy.observe(window(1_000), 2_000);
+    policy.observe(window(1_020), 4_000);
+    expect(policy.limit).toBe(2);
+    policy.observe(window(1_000), 14_000);
+    expect(policy.limit).toBe(3);
+  });
+
+  it("reduces once per failure burst, preserves the reduction across idle, and recovers", () => {
+    const policy = new AdaptiveConcurrencyPolicy();
+    policy.observe(window(1_000), 2_000);
+    policy.observe(window(1_400), 4_000);
+    policy.observe(window(1_400), 14_000);
+    expect(policy.limit).toBe(4);
+    policy.congested(15_000);
+    expect(policy.limit).toBe(2);
+    policy.congested(15_001);
+    policy.idle();
+    expect(policy.limit).toBe(2);
+    policy.observe(window(500), 18_000);
+    expect(policy.limit).toBe(2);
+    policy.observe(window(500), 25_000);
+    expect(policy.limit).toBe(3);
+  });
+
+  it("abandons interrupted probes and respects bounds", () => {
+    const policy = new AdaptiveConcurrencyPolicy(3);
+    policy.observe(window(1_000), 2_000);
+    policy.idle();
+    expect(policy.limit).toBe(2);
+    policy.observe(window(1_000), 20_000);
+    policy.observe(window(2_000), 22_000);
+    policy.observe(window(2_000), 40_000);
+    expect(policy.limit).toBe(3);
+    policy.congested(41_000);
+    policy.congested(51_000);
+    expect(policy.limit).toBe(1);
+  });
+});

--- a/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.ts
+++ b/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.ts
@@ -1,0 +1,75 @@
+export interface TransferWindow {
+  bytes: number;
+  elapsedMs: number;
+  meanDurationMs: number;
+}
+
+/** Pure controller; the scheduler supplies only sustained, busy observations. */
+export class AdaptiveConcurrencyPolicy {
+  private current = 2;
+  private baseline: { rate: number; latency: number; limit: number } | undefined;
+  private probing = false;
+  private nextProbeAt = 0;
+  private nextDecreaseAt = 0;
+  private steady: { rate: number; latency: number } | undefined;
+  private degradedWindows = 0;
+
+  constructor(private readonly maximum = 12) {
+    if (!Number.isInteger(maximum) || maximum < 1) {
+      throw new Error("Transfer concurrency maximum must be a positive integer.");
+    }
+    this.current = Math.min(this.current, maximum);
+  }
+
+  get limit(): number { return this.current; }
+
+  observe(window: TransferWindow, now: number): void {
+    if (window.bytes <= 0 || window.elapsedMs <= 0) return;
+    const rate = window.bytes / window.elapsedMs;
+    if (this.probing && this.baseline) {
+      // Keep the extra slot only when aggregate throughput improves materially.
+      if (rate < this.baseline.rate * 1.1
+        || window.meanDurationMs > this.baseline.latency * 2) {
+        this.current = this.baseline.limit;
+      }
+      this.probing = false;
+      this.baseline = undefined;
+      this.steady = undefined;
+      this.nextProbeAt = now + 10_000;
+      return;
+    }
+    if (this.steady && rate < this.steady.rate * 0.7
+      && window.meanDurationMs > this.steady.latency * 1.5) {
+      this.degradedWindows += 1;
+      if (this.degradedWindows >= 2) this.congested(now);
+      return;
+    }
+    this.degradedWindows = 0;
+    this.steady = { rate, latency: window.meanDurationMs };
+    if (now < this.nextProbeAt || this.current >= this.maximum) return;
+    this.baseline = { rate, latency: window.meanDurationMs, limit: this.current };
+    this.current += 1;
+    this.probing = true;
+  }
+
+  congested(now: number): void {
+    // A burst of failures from one group of requests causes one reduction.
+    if (now < this.nextDecreaseAt) return;
+    this.current = Math.max(1, Math.floor(this.current / 2));
+    this.baseline = undefined;
+    this.probing = false;
+    this.steady = undefined;
+    this.degradedWindows = 0;
+    this.nextDecreaseAt = now + 5_000;
+    this.nextProbeAt = now + 10_000;
+  }
+
+  idle(): void {
+    // An interrupted experiment cannot be compared against a later workload.
+    if (this.probing && this.baseline) this.current = this.baseline.limit;
+    this.baseline = undefined;
+    this.probing = false;
+    this.steady = undefined;
+    this.degradedWindows = 0;
+  }
+}

--- a/packages/sync-client/src/sync/remote/blob-client.test.ts
+++ b/packages/sync-client/src/sync/remote/blob-client.test.ts
@@ -6,6 +6,35 @@ import { SyncAuthorizedRequestClient } from "./request-client";
 
 describe("SyncBlobClient", () => {
   it.each(["upload", "download"] as const)(
+    "applies overload backoff to real %s requests and preserves the HTTP error", async direction => {
+      const pending: Array<(response: HttpResponseLike) => void> = [];
+      const client = new SyncBlobClient(new SyncAuthorizedRequestClient({
+        getApiBaseUrl: () => "https://sync.example",
+        getSyncToken: async () => ({ token: "token", expiresAt: 1_000, vaultId: "v", localVaultId: "l" }),
+        invalidateSyncToken: () => {},
+        httpClient: {
+          request: async () => await new Promise<HttpResponseLike>(resolve => pending.push(resolve)),
+        },
+      }));
+      const bytes = new Uint8Array([1]);
+      const jobs = ["a", "b", "c"].map(id => direction === "upload"
+        ? client.uploadBlob("v", id, bytes)
+        : client.downloadBlob("v", id));
+      const results = Promise.allSettled(jobs);
+      await vi.waitFor(() => expect(pending).toHaveLength(2));
+      pending[0]!({ status: 503, json: { message: "busy" } });
+      await expect(jobs[0]).rejects.toMatchObject({ status: 503, message: "busy" });
+      // Finish microtasks so a wrongly admitted third request would be visible.
+      for (let i = 0; i < 12; i += 1) await Promise.resolve();
+      expect(pending).toHaveLength(2);
+      pending[1]!({ status: 200, arrayBuffer: bytes.buffer });
+      await vi.waitFor(() => expect(pending).toHaveLength(3));
+      pending[2]!({ status: 200, arrayBuffer: bytes.buffer });
+      expect((await results).map(result => result.status)).toEqual(["rejected", "fulfilled", "fulfilled"]);
+    },
+  );
+
+  it.each(["upload", "download"] as const)(
     "refreshes authorization for a %s without changing the blob request",
     async (operation) => {
       const requests: HttpRequestInput[] = [];

--- a/packages/sync-client/src/sync/remote/blob-client.ts
+++ b/packages/sync-client/src/sync/remote/blob-client.ts
@@ -1,39 +1,52 @@
 import { extractErrorMessage, type HttpResponseLike } from "../../http/request";
 import { toArrayBuffer } from "@synch/vault-crypto";
+import { TransferScheduler } from "./transfer-scheduler";
 import type { SyncAuthorizedRequestClient } from "./request-client";
 
 export class SyncBlobClient {
-  constructor(private readonly requestClient: SyncAuthorizedRequestClient) {}
+  constructor(
+    private readonly requestClient: SyncAuthorizedRequestClient,
+    private readonly transfers = new TransferScheduler(),
+  ) {}
 
   async uploadBlob(
     vaultId: string,
     blobId: string,
     bytes: Uint8Array,
   ): Promise<void> {
-    const { response } = await this.requestClient.request({
-      path: () =>
-        `/v1/vaults/${encodeURIComponent(vaultId)}/blobs/${encodeURIComponent(blobId)}`,
-      method: "PUT",
-      body: toArrayBuffer(bytes),
-      headers: {
-        "x-blob-size": String(bytes.byteLength),
-      },
+    return await this.transfers.run("upload", async () => {
+      const { response } = await this.requestClient.request({
+        path: () =>
+          `/v1/vaults/${encodeURIComponent(vaultId)}/blobs/${encodeURIComponent(blobId)}`,
+        method: "PUT",
+        body: toArrayBuffer(bytes),
+        headers: {
+          "x-blob-size": String(bytes.byteLength),
+        },
+      });
+      this.throwUnlessUploadSucceeded(response);
+      return { value: undefined, bytes: response.status === 409 ? 0 : bytes.byteLength };
     });
-    this.throwUnlessUploadSucceeded(response);
   }
 
   async downloadBlob(vaultId: string, blobId: string): Promise<Uint8Array> {
-    const { response } = await this.requestClient.request({
-      path: () =>
-        `/v1/vaults/${encodeURIComponent(vaultId)}/blobs/${encodeURIComponent(blobId)}`,
+    return await this.transfers.run("download", async () => {
+      const { response } = await this.requestClient.request({
+        path: () =>
+          `/v1/vaults/${encodeURIComponent(vaultId)}/blobs/${encodeURIComponent(blobId)}`,
+      });
+      const bytes = this.readDownloadResponse(response);
+      return { value: bytes, bytes: bytes.byteLength };
     });
-    return this.readDownloadResponse(response);
   }
 
   private readDownloadResponse(response: HttpResponseLike): Uint8Array {
     if (response.status < 200 || response.status >= 300) {
       const message = extractErrorMessage(response.json);
-      throw new Error(message || `blob download failed with status ${response.status}`);
+      throw new SyncBlobDownloadError(
+        response.status,
+        message || `blob download failed with status ${response.status}`,
+      );
     }
 
     if (response.arrayBuffer instanceof ArrayBuffer) {
@@ -79,4 +92,11 @@ function extractErrorCode(value: unknown): string {
 
   const record = value as Record<string, unknown>;
   return typeof record.error === "string" ? record.error.trim() : "";
+}
+
+export class SyncBlobDownloadError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "SyncBlobDownloadError";
+  }
 }

--- a/packages/sync-client/src/sync/remote/transfer-scheduler.test.ts
+++ b/packages/sync-client/src/sync/remote/transfer-scheduler.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { TransferScheduler, type TransferDirection, type TransferResult } from "./transfer-scheduler";
+
+function harness() {
+  let now = 0;
+  const scheduler = new TransferScheduler(() => now);
+  const started: number[] = [];
+  const controls = new Map<number, {
+    resolve: (result: TransferResult<number>) => void;
+    reject: (error: unknown) => void;
+  }>();
+  function add(id: number, direction: TransferDirection = "upload") {
+    return scheduler.run(direction, () => {
+      started.push(id);
+      return new Promise<TransferResult<number>>((resolve, reject) => {
+        controls.set(id, { resolve, reject });
+      });
+    });
+  }
+  return { scheduler, started, controls, add, advance: (ms: number) => { now += ms; } };
+}
+
+async function flush() {
+  for (let i = 0; i < 12; i += 1) await Promise.resolve();
+}
+
+// Model bounded preparation batches with a fixed network round-trip time.
+async function transferBatch(h: ReturnType<typeof harness>, count = 12) {
+  const firstId = h.started.length;
+  const jobs = Array.from({ length: count }, (_, index) => h.add(firstId + index));
+  await flush();
+  let completed = firstId;
+  let peak = 0;
+  while (completed < firstId + count) {
+    const active = h.started.slice(completed);
+    peak = Math.max(peak, active.length);
+    h.advance(100);
+    for (const id of active) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    completed += active.length;
+    await flush();
+  }
+  await Promise.all(jobs);
+  return peak;
+}
+
+describe("TransferScheduler", () => {
+  it.each([0, 4_000])("learns across short batches excluding %i ms gaps", async gap => {
+    const h = harness();
+    for (let batch = 0; batch < 12; batch += 1) {
+      await transferBatch(h);
+      // Introduce apply delays only after establishing the baseline, so counting
+      // idle time would make the faster probe appear slower and roll it back.
+      h.advance(batch < 3 ? 0 : gap);
+    }
+    // Both the baseline and probe require multiple batches. The extra slot
+    // must survive the gaps and be retained after measuring its throughput.
+    expect(await transferBatch(h)).toBeGreaterThanOrEqual(3);
+    await h.scheduler.dispose();
+  });
+
+  it("discards partial observations after a long gap", async () => {
+    const h = harness();
+    for (let batch = 0; batch < 12; batch += 1) {
+      expect(await transferBatch(h)).toBe(2);
+      h.advance(10_000);
+    }
+    await h.scheduler.dispose();
+  });
+
+  it("rolls back an unfinished probe after a long gap", async () => {
+    const h = harness();
+    for (let batch = 0; batch < 4; batch += 1) await transferBatch(h);
+    expect(await transferBatch(h)).toBe(3);
+    h.advance(10_000);
+    expect(await transferBatch(h)).toBe(2);
+    await h.scheduler.dispose();
+  });
+
+  it("discards partial observations on application errors", async () => {
+    const h = harness();
+    for (let batch = 0; batch < 3; batch += 1) await transferBatch(h);
+    const id = h.started.length;
+    const job = h.add(id);
+    await flush();
+    h.controls.get(id)!.reject({ status: 403 });
+    await expect(job).rejects.toEqual({ status: 403 });
+    await flush();
+    expect(await transferBatch(h)).toBe(2);
+    expect(await transferBatch(h)).toBe(2);
+    await h.scheduler.dispose();
+  });
+
+  it("bounds each direction independently and preserves FIFO admission", async () => {
+    const h = harness();
+    const jobs = [h.add(1), h.add(2), h.add(3), h.add(4, "download"), h.add(5, "download")];
+    await flush();
+    expect(h.started).toEqual([1, 2, 4, 5]);
+    h.controls.get(2)!.resolve({ value: 2, bytes: 100 });
+    await flush();
+    expect(h.started).toEqual([1, 2, 4, 5, 3]);
+    for (const id of [1, 3, 4, 5]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    await expect(Promise.all(jobs)).resolves.toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("reduces admission after overload without cancelling active requests or retrying", async () => {
+    const h = harness();
+    const jobs = [h.add(1), h.add(2), h.add(3)];
+    const results = Promise.allSettled(jobs);
+    await flush();
+    const error = { status: 503 };
+    h.controls.get(1)!.reject(error);
+    await flush();
+    expect(h.started).toEqual([1, 2]);
+    h.controls.get(2)!.resolve({ value: 2, bytes: 100 });
+    await flush();
+    expect(h.started).toEqual([1, 2, 3]);
+    h.controls.get(3)!.resolve({ value: 3, bytes: 100 });
+    expect((await results)[0]).toEqual({ status: "rejected", reason: error });
+  });
+
+  it.each([{ status: 401 }, { status: 403 }, { status: 413 }, new SyntaxError("invalid JSON")])(
+    "does not treat application failures as congestion: %s", async error => {
+      const h = harness();
+      const results = Promise.allSettled([h.add(1), h.add(2), h.add(3)]);
+      await flush();
+      h.controls.get(1)!.reject(error);
+      await flush();
+      expect(h.started).toEqual([1, 2, 3]);
+      for (const id of [2, 3]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+      await results;
+    },
+  );
+
+  it("probes under sustained demand using wall-clock aggregate throughput", async () => {
+    const h = harness();
+    const results = Promise.allSettled(Array.from({ length: 12 }, (_, id) => h.add(id)));
+    await flush();
+    for (let id = 0; id < 4; id += 1) {
+      h.advance(500);
+      h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+      await flush();
+    }
+    expect(h.started).toHaveLength(7); // Four finished, three now active.
+    const closing = h.scheduler.dispose();
+    for (const id of [4, 5, 6]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    await closing;
+    await results;
+  });
+
+  it("rejects queued work on disposal and waits for active transfers", async () => {
+    const h = harness();
+    const results = Promise.allSettled([h.add(1), h.add(2), h.add(3)]);
+    await flush();
+    let disposed = false;
+    const closing = h.scheduler.dispose().then(() => { disposed = true; });
+    await flush();
+    expect(disposed).toBe(false);
+    expect(h.started).toEqual([1, 2]);
+    await expect(h.add(4)).rejects.toThrow("closed");
+    for (const id of [1, 2]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    await closing;
+    expect((await results)[2]?.status).toBe("rejected");
+  });
+});

--- a/packages/sync-client/src/sync/remote/transfer-scheduler.ts
+++ b/packages/sync-client/src/sync/remote/transfer-scheduler.ts
@@ -1,0 +1,120 @@
+import { AdaptiveConcurrencyPolicy } from "./adaptive-concurrency-policy";
+
+export type TransferDirection = "upload" | "download";
+export interface TransferResult<T> { value: T; bytes: number }
+interface Lane {
+  policy: AdaptiveConcurrencyPolicy;
+  queue: Array<() => void>;
+  active: number;
+  pausedAt?: number;
+  window?: {
+    busySince?: number;
+    elapsedMs: number;
+    bytes: number;
+    count: number;
+    duration: number;
+  };
+}
+
+const OBSERVATION_EXPIRY_MS = 10_000;
+
+/** Engine-scoped admission control. Retries remain owned by the sync engine. */
+export class TransferScheduler {
+  private readonly lanes: Record<TransferDirection, Lane>;
+  private closed = false;
+  private readonly pending = new Set<Promise<unknown>>();
+
+  constructor(private readonly now: () => number = () => performance.now()) {
+    const lane = (): Lane => ({ policy: new AdaptiveConcurrencyPolicy(), queue: [], active: 0 });
+    this.lanes = { upload: lane(), download: lane() };
+  }
+
+  run<T>(direction: TransferDirection, work: () => Promise<TransferResult<T>>): Promise<T> {
+    if (this.closed) return Promise.reject(new Error("Transfer scheduler is closed."));
+    const lane = this.lanes[direction];
+    const promise = new Promise<T>((resolve, reject) => {
+      lane.queue.push(() => {
+        if (this.closed) {
+          reject(new Error("Transfer scheduler is closed."));
+          return;
+        }
+        lane.active += 1;
+        const start = this.now();
+        void Promise.resolve().then(work).then(result => {
+          if (lane.window?.busySince !== undefined) {
+            lane.window.bytes += result.bytes;
+            lane.window.count += 1;
+            lane.window.duration += this.now() - start;
+          }
+          resolve(result.value);
+        }, error => {
+          if (isCongestionError(error)) lane.policy.congested(this.now());
+          else lane.policy.idle();
+          lane.window = undefined;
+          reject(error);
+        }).finally(() => {
+          lane.active -= 1;
+          this.pump(lane);
+        });
+      });
+      this.pump(lane);
+    });
+    this.pending.add(promise);
+    void promise.then(() => this.pending.delete(promise), () => this.pending.delete(promise));
+    return promise;
+  }
+
+  async dispose(): Promise<void> {
+    this.closed = true;
+    for (const lane of Object.values(this.lanes)) {
+      for (const start of lane.queue.splice(0)) start();
+    }
+    await Promise.allSettled([...this.pending]);
+  }
+
+  private pump(lane: Lane): void {
+    const now = this.now();
+    // Brief preparation/apply gaps belong to the same workload. A long gap
+    // invalidates both accumulated samples and any unfinished concurrency probe.
+    if (lane.pausedAt !== undefined && now - lane.pausedAt >= OBSERVATION_EXPIRY_MS) {
+      lane.window = undefined;
+      lane.policy.idle();
+      lane.pausedAt = undefined;
+    }
+    const window = lane.window;
+    if (window?.busySince !== undefined) {
+      window.elapsedMs += now - window.busySince;
+      window.busySince = now;
+    }
+    if (window && window.elapsedMs >= 2_000 && window.count >= 4) {
+      lane.policy.observe({
+        bytes: window.bytes,
+        elapsedMs: window.elapsedMs,
+        meanDurationMs: window.duration / window.count,
+      }, now);
+      lane.window = undefined;
+    }
+    while (!this.closed && lane.active < lane.policy.limit && lane.queue.length > 0) {
+      lane.queue.shift()!();
+    }
+    if (lane.queue.length > 0 && lane.active >= lane.policy.limit) {
+      lane.pausedAt = undefined;
+      lane.window ??= { elapsedMs: 0, bytes: 0, count: 0, duration: 0 };
+      lane.window.busySince = now;
+    } else {
+      // Pause the busy clock and ignore tail completions until demand resumes.
+      // Keeping the partial window lets short batches eventually yield a sample.
+      if (lane.window) lane.window.busySince = undefined;
+      lane.pausedAt ??= now;
+    }
+  }
+}
+
+function isCongestionError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const value = error as { status?: unknown; name?: unknown; code?: unknown };
+  return [408, 429, 502, 503, 504].includes(value.status as number)
+    || value.name === "TimeoutError"
+    || value.code === "ETIMEDOUT"
+    || value.code === "ESOCKETTIMEDOUT";
+}

--- a/packages/sync-client/src/sync/runtime/sync-engine.ts
+++ b/packages/sync-client/src/sync/runtime/sync-engine.ts
@@ -31,6 +31,7 @@ import { SyncPullService } from "../engine/pull-service";
 import { SyncPushService } from "../engine/push-service";
 import { SyncAuthorizedRequestClient } from "../remote/request-client";
 import { SyncBlobClient } from "../remote/blob-client";
+import { TransferScheduler } from "../remote/transfer-scheduler";
 import {
   type EntryVersion,
   type DeletedEntryPageCursor,
@@ -138,6 +139,7 @@ export class SyncEngine {
   private readonly syncEventRecorder: SyncEventRecorder;
   private readonly syncRequestClient: SyncAuthorizedRequestClient;
   private readonly syncBlobClient: SyncBlobClient;
+  private readonly transferScheduler = new TransferScheduler();
   private readonly syncPushService: SyncPushService;
   private readonly syncLocalReconcileService: SyncLocalReconcileService;
   private readonly syncAutoLoop: SyncAutoLoop;
@@ -163,7 +165,7 @@ export class SyncEngine {
       invalidateSyncToken: () => this.deps.invalidateSyncToken(),
       httpClient: this.deps.httpClient,
     });
-    this.syncBlobClient = new SyncBlobClient(this.syncRequestClient);
+    this.syncBlobClient = new SyncBlobClient(this.syncRequestClient, this.transferScheduler);
     this.syncPushService = new SyncPushService({
       getSyncToken: async () => await this.deps.getSyncToken(),
       getSyncStore: () => this.syncStore,
@@ -390,6 +392,7 @@ export class SyncEngine {
 
     this.disposed = true;
     this.stopAutoSync();
+    await this.transferScheduler.dispose();
     if (this.ownsContentRuntime) {
       await this.contentRuntime.dispose();
     }


### PR DESCRIPTION
Blob requests currently inherit fixed preparation concurrency, so transfer admission cannot respond independently to server overload or observed network performance. This change gives each sync engine independent upload/download queues with adaptive concurrency, starting at two transfers per direction and probing upward under sustained demand.

The scheduler backs off on overload and timeout signals, preserves HTTP errors, and rejects queued work while joining active transfers on disposal. Short busy windows accumulate across preparation/apply gaps without counting idle time; long gaps and failures invalidate observations. Preparation caps remain as resource bounds, with follow-up TODOs for CPU/memory budgets. The cumulative Obsidian release note covers the behavior.

Refs #38. This is related transfer-control work; it does not establish that the reported large-file upload failure is resolved and does not close the issue.

## Validation

- Sync-client: 357 tests passed; typecheck passed.
- Obsidian plugin: 263 tests passed; typecheck passed.
- Real local Node benchmark: six scenarios, one rehearsal and five measured samples per side, alternating order. All samples passed completion and file-content verification.

## Measured performance and next PR

The baseline is `3d7f8cf3c29825b075c46f46872ed5900b448fbe` (fixed concurrency); the candidate includes the complete adaptive-concurrency change and the short-batch observation fix. These numbers do not isolate the observation fix alone.

| Scenario | Base median | Candidate median | Duration change |
| --- | ---: | ---: | ---: |
| pull-notes-no-delay | 599.9 ms | 705.6 ms | +17.6% |
| pull-notes-page-40ms | 704.5 ms | 2043.0 ms | +190.0% |
| pull-notes-page-120ms | 827.7 ms | 2172.3 ms | +162.5% |
| push-mixed-no-delay | 522.2 ms | 593.7 ms | +13.7% |
| push-mixed-latency | 1091.0 ms | 4980.7 ms | +356.5% |
| push-mixed-slow-attachment | 1181.1 ms | 5388.6 ms | +356.2% |

This is a known regression on these short workloads, not a demonstrated throughput improvement. Starting at two transfers and waiting for two seconds of busy observations before probing appears too conservative for short syncs. The benchmark uses independent request delays without a shared bandwidth limit, so it does not establish behavior under bandwidth saturation, changing link capacity, or real Obsidian/mobile conditions.

A separate follow-up PR will add shared bandwidth constraints and varying-capacity scenarios for small notes and large attachments, then tune initial concurrency and ramp-up against both constrained and unconstrained workloads. Keep the current quick scenarios as regression coverage.
