### PR TITLE
Improve adaptive transfer startup and add bandwidth benchmarks

### DIFF
--- a/apps/obsidian-plugin/release-notes/next.md
+++ b/apps/obsidian-plugin/release-notes/next.md
@@ -4,7 +4,7 @@
 
 ## Changed
 
-- Automatically adjust simultaneous uploads and downloads based on observed transfer performance and server overload.
+- Automatically adjust simultaneous uploads and downloads based on observed transfer performance and server overload, with faster startup for short syncs.
 
 - Require encrypted sync and conflict recovery checks before publishing plugin releases.
 - Reduce repeated encryption work when retrying uploads after an interrupted sync.

--- a/benchmarks/sync/README.md
+++ b/benchmarks/sync/README.md
@@ -4,7 +4,8 @@ System-level sync measurements against the production API over real HTTP and
 WebSocket. Local Cloudflare is the default; Node measures the self-hosted backend.
 The measured client uses Node, an ordinary filesystem vault and an in-memory sync
 store. Results do not represent deployed Cloudflare latency, Obsidian/Dexie, browser
-workers, mobile performance, or shared network bandwidth.
+workers, mobile performance, or TCP behavior. Bandwidth profiles simulate shared body-byte
+capacity at the client transport boundary; they do not shape the loopback network.
 
 Requires Node 24, `pnpm install --frozen-lockfile`, and permission to listen on
 loopback ports and start child processes. No deployed service, Cloudflare account,
@@ -18,6 +19,7 @@ From the repository root:
 ```sh
 pnpm bench:sync -- --runtime cloudflare --suite quick
 pnpm bench:sync -- --runtime node --suite full
+pnpm bench:sync:compare -- --base origin/main --runtime node --suite bandwidth
 pnpm bench:sync -- --runtime node --scenario pull-notes-no-delay --iterations 1 --warmup 0 --output /tmp/sync-run.json
 pnpm bench:sync:compare -- --base origin/main --runtime cloudflare --suite quick
 ```
@@ -41,7 +43,8 @@ from concurrent validation runs or different environments.
 
 ## Suites and workload recipes
 
-`quick` runs the six mixed/pagination profiles. `full` adds three bulk scenarios.
+`quick` runs the six mixed/pagination profiles. `bandwidth` runs four shared-capacity profiles.
+`full` includes both suites and three bulk scenarios.
 Each profile uses one discarded rehearsal and five measured samples by default.
 `--iterations` accepts 1–100; `--warmup` accepts 0–10. A single sample is useful for
 correctness verification, not evidence of a performance improvement.
@@ -57,6 +60,28 @@ correctness verification, not evidence of a performance improvement.
 | `push-mixed-no-delay` | 240 distinct 4 KiB notes and one 8 MiB attachment, attachment queued first |
 | `push-mixed-latency` | Same mixed data; 40 ms before every upload and commit request |
 | `push-mixed-slow-attachment` | Same delays plus 800 ms before the attachment upload |
+
+Bandwidth profiles use the mixed fixture (240 x 4 KiB notes and one 8 MiB
+attachment) for both push and pull, with a 40 ms pre-request delay per blob:
+
+| Scenario | Aggregate encrypted body capacity |
+| --- | --- |
+| `pull-mixed-bandwidth-2MiB`, `push-mixed-bandwidth-2MiB` | 2 MiB/s throughout |
+| `pull-mixed-bandwidth-drop`, `push-mixed-bandwidth-drop` | 2 MiB/s for the first second, then 512 KiB/s |
+
+One shared budget per measured device covers all concurrent blob bodies. Pending
+bodies share capacity equally, with unused shares redistributed when a body
+finishes. Idle time earns no credit. The model charges upload bytes before issuing
+the real PUT and download bytes after receiving the real response, before returning
+it to the client. It ticks every 10 ms and accounts for capacity transitions using
+elapsed measurement time. Seeding and verification remain unshaped.
+
+This models bandwidth contention as observed by transfer admission, not packet
+loss, TCP congestion windows, socket backpressure, or streaming memory usage.
+Headers, metadata and WebSocket traffic are excluded from the byte budget. Real
+server work does not overlap the simulated body transmission for a given request.
+Use these profiles to compare admission policies under a reproducible capacity
+constraint, alongside the unchanged quick suite for short-sync regressions.
 
 Delays are independent asynchronous waits before actual requests. They model
 scheduling conditions, not actual RTT or shared bandwidth. Responses, validation,

--- a/benchmarks/sync/src/bandwidth.test.ts
+++ b/benchmarks/sync/src/bandwidth.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { SharedBandwidth } from "./bandwidth";
+
+afterEach(() => vi.useRealTimers());
+
+it("shares one budget, allowing small bodies past a large attachment", async () => {
+  vi.useFakeTimers();
+  const link = new SharedBandwidth([{ afterMs: 0, bytesPerSecond: 1000 }], () => Date.now());
+  let large = false;
+  let small = false;
+  void link.transfer(900).then(() => { large = true; });
+  void link.transfer(100).then(() => { small = true; });
+  await vi.advanceTimersByTimeAsync(190);
+  expect(small).toBe(false);
+  await vi.advanceTimersByTimeAsync(10);
+  expect(small).toBe(true);
+  expect(large).toBe(false);
+  await vi.advanceTimersByTimeAsync(790);
+  expect(large).toBe(false);
+  await vi.advanceTimersByTimeAsync(10);
+  expect(large).toBe(true);
+  expect(vi.getTimerCount()).toBe(0);
+});
+
+it("integrates a capacity change for already active transfers", async () => {
+  vi.useFakeTimers();
+  const link = new SharedBandwidth([{ afterMs: 0, bytesPerSecond: 1000 }, { afterMs: 500, bytesPerSecond: 500 }], () => Date.now());
+  let done = false;
+  void link.transfer(1000).then(() => { done = true; });
+  await vi.advanceTimersByTimeAsync(1490);
+  expect(done).toBe(false);
+  await vi.advanceTimersByTimeAsync(10);
+  expect(done).toBe(true);
+});
+
+it("does not bank idle capacity or charge a new body for time before admission", async () => {
+  vi.useFakeTimers();
+  const link = new SharedBandwidth([{ afterMs: 0, bytesPerSecond: 1000 }], () => Date.now());
+  await vi.advanceTimersByTimeAsync(10_000);
+  let done = false;
+  void link.transfer(100).then(() => { done = true; });
+  await vi.advanceTimersByTimeAsync(50);
+  let second = false;
+  void link.transfer(100).then(() => { second = true; });
+  await vi.advanceTimersByTimeAsync(90);
+  expect(done).toBe(false);
+  await vi.advanceTimersByTimeAsync(10);
+  expect(done).toBe(true);
+  expect(second).toBe(false);
+  await vi.advanceTimersByTimeAsync(50);
+  expect(second).toBe(true);
+});
+
+it("rejects invalid schedules", () => {
+  for (const steps of [[], [{ afterMs: 0, bytesPerSecond: 0 }], [{ afterMs: 1, bytesPerSecond: 1 }], [{ afterMs: 0, bytesPerSecond: 1 }, { afterMs: 0, bytesPerSecond: 2 }]]) {
+    expect(() => new SharedBandwidth(steps)).toThrow("Invalid bandwidth schedule");
+  }
+});

--- a/benchmarks/sync/src/bandwidth.ts
+++ b/benchmarks/sync/src/bandwidth.ts
@@ -1,0 +1,59 @@
+export interface BandwidthStep { afterMs: number; bytesPerSecond: number }
+
+/** Application-level fair sharing model, not TCP or kernel traffic shaping.
+ * Each tick spends one aggregate budget across all pending bodies. Idle time
+ * earns no credit, and a large attachment cannot reserve future capacity.
+ */
+export class SharedBandwidth {
+  private readonly pending: Array<{ remaining: number; resolve: () => void }> = [];
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private readonly started: number;
+  private last: number;
+
+  constructor(private readonly steps: readonly BandwidthStep[], private readonly now = () => performance.now()) {
+    if (!steps.length || steps[0].afterMs !== 0 || steps.some((step, i) =>
+      !Number.isFinite(step.bytesPerSecond) || step.bytesPerSecond <= 0
+      || !Number.isFinite(step.afterMs) || step.afterMs < 0
+      || (i > 0 && step.afterMs <= steps[i - 1].afterMs))) throw new Error("Invalid bandwidth schedule");
+    this.started = this.last = now();
+  }
+
+  transfer(bytes: number): Promise<void> {
+    if (!Number.isFinite(bytes) || bytes < 0) throw new Error("Invalid transfer size");
+    if (!bytes) return Promise.resolve();
+    // Account for existing transfers before admitting a new participant.
+    this.advance();
+    return new Promise(resolve => {
+      this.pending.push({ remaining: bytes, resolve });
+      this.schedule();
+    });
+  }
+
+  private advance() {
+    const now = this.now();
+    let budget = 0;
+    for (let i = 0; i < this.steps.length; i++) {
+      const from = Math.max(this.last, this.started + this.steps[i].afterMs);
+      const to = Math.min(now, this.started + (this.steps[i + 1]?.afterMs ?? Infinity));
+      budget += Math.max(0, to - from) * this.steps[i].bytesPerSecond / 1000;
+    }
+    this.last = now;
+    while (budget > 0 && this.pending.length) {
+      const share = Math.min(budget / this.pending.length, ...this.pending.map(job => job.remaining));
+      budget -= share * this.pending.length;
+      for (const job of this.pending) job.remaining -= share;
+      for (let i = this.pending.length - 1; i >= 0; i--) {
+        if (this.pending[i].remaining <= 1e-7) this.pending.splice(i, 1)[0].resolve();
+      }
+    }
+  }
+
+  private schedule() {
+    if (this.timer) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.advance();
+      if (this.pending.length) this.schedule();
+    }, 10);
+  }
+}

--- a/benchmarks/sync/src/device.ts
+++ b/benchmarks/sync/src/device.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SYNC_FILE_RULES, DEFAULT_VAULT_CONFIG_SYNC_RULES } from "@synch
 import { createTestSyncStore } from "@synch/sync-client/testing";
 import type { TestVault } from "@synch/sync-testkit/account";
 import { createTransport } from "@synch/sync-testkit/transport";
+import { SharedBandwidth } from "./bandwidth";
 import { FilesystemVault } from "./vault";
 import { SyncMetrics } from "./metrics";
 import { directScenario, type Scenario } from "./profiles";
@@ -16,6 +17,7 @@ export class Device {
   private deferred = true;
   private measuring = false;
   private localId = "";
+  private bandwidth: SharedBandwidth | undefined;
   private profile: Scenario = directScenario;
   cursor = 0;
   policy: { storageLimitBytes: number; maxFileSizeBytes: number } | undefined;
@@ -64,7 +66,13 @@ export class Device {
     const error = (message: unknown) => { if (this.errors.length < 20) this.errors.push(String(message)); };
     this.engine = new SyncEngine({
       vaultAdapter: this.vault, vaultConfigSource: { listFiles: async () => [] }, changeSource: { start() {} },
-      httpClient: this.transport.httpClient, createWebSocket: this.transport.createWebSocket,
+      httpClient: { request: async input => {
+        const shaped = this.measuring && input.url.includes("/blobs/") ? this.bandwidth : undefined;
+        if (input.method === "PUT" && input.body instanceof ArrayBuffer) await shaped?.transfer(input.body.byteLength);
+        const response = await this.transport.httpClient.request(input);
+        if (input.method !== "PUT" && response.arrayBuffer) await shaped?.transfer(response.arrayBuffer.byteLength);
+        return response;
+      } }, createWebSocket: this.transport.createWebSocket,
       getApiBaseUrl: () => baseUrl, getSyncToken: () => remote.token(this.localId), invalidateSyncToken() {},
       getRemoteVaultKey: () => key, getConfigDir: () => ".obsidian",
       getSyncFileRules: () => ({ ...DEFAULT_SYNC_FILE_RULES, includeOtherFiles: true }),
@@ -112,6 +120,7 @@ export class Device {
   }
   async measure(profile: Scenario) {
     this.profile = profile;
+    this.bandwidth = profile.bandwidth ? new SharedBandwidth(profile.bandwidth) : undefined;
     this.measuring = true;
     this.metrics.start();
     try { await this.sync(); }

--- a/benchmarks/sync/src/profiles.ts
+++ b/benchmarks/sync/src/profiles.ts
@@ -4,6 +4,7 @@ export type Scenario = {
   version: 1;
   fixture: "bulk" | "notes" | "mixed";
   operation: "pull" | "incremental" | "push";
+  bandwidth?: import("./bandwidth").BandwidthStep[];
   pageDelayMs: number;
   downloadDelayMs: number;
   uploadDelayMs: number;
@@ -20,13 +21,23 @@ export const scenarios: Scenario[] = [
   { ...direct, id: "push-mixed-latency", fixture: "mixed", operation: "push", uploadDelayMs: 40, commitDelayMs: 40 },
   { ...direct, id: "push-mixed-slow-attachment", fixture: "mixed", operation: "push", uploadDelayMs: 40, commitDelayMs: 40, attachmentDelayMs: 800 },
 ];
+for (const operation of ["pull", "push"] as const) {
+  for (const varying of [false, true]) {
+    scenarios.push({ ...direct, id: `${operation}-mixed-bandwidth-${varying ? "drop" : "2MiB"}`,
+      fixture: "mixed", operation, uploadDelayMs: 40, downloadDelayMs: 40,
+      bandwidth: varying
+        ? [{ afterMs: 0, bytesPerSecond: 2 * 1024 ** 2 }, { afterMs: 1_000, bytesPerSecond: 512 * 1024 }]
+        : [{ afterMs: 0, bytesPerSecond: 2 * 1024 ** 2 }],
+    });
+  }
+}
 export const directScenario = { ...direct, id: "setup", fixture: "notes", operation: "push" } satisfies Scenario;
 export function selectScenarios(suite: string, id?: string) {
-  if (suite !== "quick" && suite !== "full") throw new Error(`Unknown suite: ${suite}`);
+  if (suite !== "quick" && suite !== "full" && suite !== "bandwidth") throw new Error(`Unknown suite: ${suite}`);
   if (id) {
     const selected = scenarios.find(s => s.id === id);
     if (!selected) throw new Error(`Unknown scenario: ${id}`);
     return [selected];
   }
-  return scenarios.filter(s => suite === "full" || s.fixture !== "bulk");
+  return scenarios.filter(s => suite === "full" || (suite === "bandwidth" ? !!s.bandwidth : s.fixture !== "bulk" && !s.bandwidth));
 }

--- a/benchmarks/sync/src/report.test.ts
+++ b/benchmarks/sync/src/report.test.ts
@@ -25,6 +25,16 @@ describe("durable comparison results", () => {
       expect(() => assertComparable(base, candidate)).toThrow("Incompatible");
     }
   });
+  it("validates bandwidth schedules and rejects comparisons with different capacities", () => {
+    const base = structuredClone(report());
+    base.scenarios[0].scenario.bandwidth = [{ afterMs: 0, bytesPerSecond: 1024 }];
+    expect(() => validateReport(base)).not.toThrow();
+    const candidate = structuredClone(base);
+    candidate.scenarios[0].scenario.bandwidth![0].bytesPerSecond *= 2;
+    expect(() => assertComparable(base, candidate)).toThrow("Incompatible");
+    candidate.scenarios[0].scenario.bandwidth![0].bytesPerSecond = 0;
+    expect(() => validateReport(candidate)).toThrow();
+  });
   it("retains failures without claiming a speedup from remaining samples", () => {
     const base = structuredClone(report()), candidate = structuredClone(base);
     candidate.options.iterations = base.options.iterations = 2;

--- a/benchmarks/sync/src/report.ts
+++ b/benchmarks/sync/src/report.ts
@@ -53,6 +53,11 @@ export function validateReport(input: unknown): asserts input is Report | Compar
   if (new Set(value.scenarios.map((g: any) => g?.scenario?.id)).size !== value.scenarios.length) fail();
   for (const group of value.scenarios) {
     if (!group.scenario || !/^[a-zA-Z0-9-]{1,80}$/.test(group.scenario.id) || !Array.isArray(group.samples) || group.samples.length > 110) fail();
+    const bandwidth = group.scenario.bandwidth;
+    if (bandwidth !== undefined && (!Array.isArray(bandwidth) || !bandwidth.length || bandwidth.length > 20
+      || bandwidth.some((step: any, i: number) => !step || !nonnegative(step.afterMs)
+        || !nonnegative(step.bytesPerSecond) || step.bytesPerSecond === 0
+        || (i === 0 ? step.afterMs !== 0 : step.afterMs <= bandwidth[i - 1].afterMs)))) fail();
     if (group.scenario.version !== 1 || !["bulk", "notes", "mixed"].includes(group.scenario.fixture) || !["pull", "push", "incremental"].includes(group.scenario.operation) || ["pageDelayMs", "downloadDelayMs", "uploadDelayMs", "commitDelayMs", "attachmentDelayMs"].some(k => !nonnegative(group.scenario[k]))) fail();
     for (const sample of group.samples) {
       if (!["passed", "failed"].includes(sample.status) || typeof sample.rehearsal !== "boolean") fail();

--- a/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.test.ts
+++ b/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.test.ts
@@ -12,57 +12,56 @@ describe("AdaptiveConcurrencyPolicy", () => {
     policy.observe(window(500, 1_000), 6_000);
     expect(policy.limit).toBe(1);
   });
-  it("keeps a probe only if throughput improves without excessive latency", () => {
+  it("starts with bounded parallelism and keeps increasing after successful probes", () => {
     const policy = new AdaptiveConcurrencyPolicy();
+    expect(policy.limit).toBe(8);
     policy.observe(window(1_000), 2_000);
-    expect(policy.limit).toBe(3);
+    expect(policy.limit).toBe(9);
     policy.observe(window(1_300), 4_000);
-    expect(policy.limit).toBe(3);
+    expect(policy.limit).toBe(9);
     policy.observe(window(1_300), 6_000);
-    expect(policy.limit).toBe(3);
-    policy.observe(window(1_300), 14_000);
-    expect(policy.limit).toBe(4);
-    policy.observe(window(1_800, 1_100), 16_000);
-    expect(policy.limit).toBe(3);
+    expect(policy.limit).toBe(10);
+    policy.observe(window(1_800, 1_100), 8_000);
+    expect(policy.limit).toBe(9);
   });
 
   it("rolls back a plateau and retries after cooldown", () => {
     const policy = new AdaptiveConcurrencyPolicy();
     policy.observe(window(1_000), 2_000);
     policy.observe(window(1_020), 4_000);
-    expect(policy.limit).toBe(2);
+    expect(policy.limit).toBe(8);
+    policy.observe(window(1_000), 6_000);
+    expect(policy.limit).toBe(8);
     policy.observe(window(1_000), 14_000);
-    expect(policy.limit).toBe(3);
+    expect(policy.limit).toBe(9);
   });
 
   it("reduces once per failure burst, preserves the reduction across idle, and recovers", () => {
     const policy = new AdaptiveConcurrencyPolicy();
-    policy.observe(window(1_000), 2_000);
-    policy.observe(window(1_400), 4_000);
-    policy.observe(window(1_400), 14_000);
+    policy.congested(0);
     expect(policy.limit).toBe(4);
-    policy.congested(15_000);
-    expect(policy.limit).toBe(2);
-    policy.congested(15_001);
+    policy.congested(1);
     policy.idle();
-    expect(policy.limit).toBe(2);
-    policy.observe(window(500), 18_000);
-    expect(policy.limit).toBe(2);
-    policy.observe(window(500), 25_000);
-    expect(policy.limit).toBe(3);
+    expect(policy.limit).toBe(4);
+    policy.observe(window(500), 2_000);
+    expect(policy.limit).toBe(4);
+    policy.observe(window(500), 10_000);
+    expect(policy.limit).toBe(5);
+    policy.observe(window(700), 12_000);
+    policy.observe(window(700), 14_000);
+    expect(policy.limit).toBe(6);
   });
 
   it("abandons interrupted probes and respects bounds", () => {
-    const policy = new AdaptiveConcurrencyPolicy(3);
+    const policy = new AdaptiveConcurrencyPolicy(9);
     policy.observe(window(1_000), 2_000);
     policy.idle();
-    expect(policy.limit).toBe(2);
+    expect(policy.limit).toBe(8);
     policy.observe(window(1_000), 20_000);
     policy.observe(window(2_000), 22_000);
     policy.observe(window(2_000), 40_000);
-    expect(policy.limit).toBe(3);
-    policy.congested(41_000);
-    policy.congested(51_000);
+    expect(policy.limit).toBe(9);
+    for (let now = 41_000; now < 70_000; now += 5_000) policy.congested(now);
     expect(policy.limit).toBe(1);
   });
 });

--- a/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.ts
+++ b/packages/sync-client/src/sync/remote/adaptive-concurrency-policy.ts
@@ -6,7 +6,9 @@ export interface TransferWindow {
 
 /** Pure controller; the scheduler supplies only sustained, busy observations. */
 export class AdaptiveConcurrencyPolicy {
-  private current = 2;
+  // Short syncs often finish before the first observation. Start below the
+  // preparation ceiling, with enough parallelism to hide request latency.
+  private current = 8;
   private baseline: { rate: number; latency: number; limit: number } | undefined;
   private probing = false;
   private nextProbeAt = 0;
@@ -28,14 +30,16 @@ export class AdaptiveConcurrencyPolicy {
     const rate = window.bytes / window.elapsedMs;
     if (this.probing && this.baseline) {
       // Keep the extra slot only when aggregate throughput improves materially.
-      if (rate < this.baseline.rate * 1.1
-        || window.meanDurationMs > this.baseline.latency * 2) {
+      const improved = rate >= this.baseline.rate * 1.1
+        && window.meanDurationMs <= this.baseline.latency * 2;
+      if (!improved) {
         this.current = this.baseline.limit;
       }
       this.probing = false;
       this.baseline = undefined;
       this.steady = undefined;
-      this.nextProbeAt = now + 10_000;
+      // Cool down after saturation, but keep exploring when capacity is growing.
+      this.nextProbeAt = improved ? now : now + 10_000;
       return;
     }
     if (this.steady && rate < this.steady.rate * 0.7

--- a/packages/sync-client/src/sync/remote/blob-client.test.ts
+++ b/packages/sync-client/src/sync/remote/blob-client.test.ts
@@ -17,20 +17,21 @@ describe("SyncBlobClient", () => {
         },
       }));
       const bytes = new Uint8Array([1]);
-      const jobs = ["a", "b", "c"].map(id => direction === "upload"
+      const jobs = Array.from({ length: 9 }, (_, i) => String(i)).map(id => direction === "upload"
         ? client.uploadBlob("v", id, bytes)
         : client.downloadBlob("v", id));
       const results = Promise.allSettled(jobs);
-      await vi.waitFor(() => expect(pending).toHaveLength(2));
+      await vi.waitFor(() => expect(pending).toHaveLength(8));
       pending[0]!({ status: 503, json: { message: "busy" } });
       await expect(jobs[0]).rejects.toMatchObject({ status: 503, message: "busy" });
-      // Finish microtasks so a wrongly admitted third request would be visible.
+      for (const id of [1, 2, 3]) pending[id]!({ status: 200, arrayBuffer: bytes.buffer });
+      // Four remain active at the reduced limit; the ninth must stay queued.
       for (let i = 0; i < 12; i += 1) await Promise.resolve();
-      expect(pending).toHaveLength(2);
-      pending[1]!({ status: 200, arrayBuffer: bytes.buffer });
-      await vi.waitFor(() => expect(pending).toHaveLength(3));
-      pending[2]!({ status: 200, arrayBuffer: bytes.buffer });
-      expect((await results).map(result => result.status)).toEqual(["rejected", "fulfilled", "fulfilled"]);
+      expect(pending).toHaveLength(8);
+      pending[4]!({ status: 200, arrayBuffer: bytes.buffer });
+      await vi.waitFor(() => expect(pending).toHaveLength(9));
+      for (const id of [5, 6, 7, 8]) pending[id]!({ status: 200, arrayBuffer: bytes.buffer });
+      expect((await results).map(result => result.status)).toEqual(["rejected", ...Array(8).fill("fulfilled")]);
     },
   );
 

--- a/packages/sync-client/src/sync/remote/transfer-scheduler.test.ts
+++ b/packages/sync-client/src/sync/remote/transfer-scheduler.test.ts
@@ -25,7 +25,7 @@ async function flush() {
 }
 
 // Model bounded preparation batches with a fixed network round-trip time.
-async function transferBatch(h: ReturnType<typeof harness>, count = 12) {
+async function transferBatch(h: ReturnType<typeof harness>, count = 48) {
   const firstId = h.started.length;
   const jobs = Array.from({ length: count }, (_, index) => h.add(firstId + index));
   await flush();
@@ -54,14 +54,14 @@ describe("TransferScheduler", () => {
     }
     // Both the baseline and probe require multiple batches. The extra slot
     // must survive the gaps and be retained after measuring its throughput.
-    expect(await transferBatch(h)).toBeGreaterThanOrEqual(3);
+    expect(await transferBatch(h)).toBeGreaterThanOrEqual(9);
     await h.scheduler.dispose();
   });
 
   it("discards partial observations after a long gap", async () => {
     const h = harness();
     for (let batch = 0; batch < 12; batch += 1) {
-      expect(await transferBatch(h)).toBe(2);
+      expect(await transferBatch(h)).toBe(8);
       h.advance(10_000);
     }
     await h.scheduler.dispose();
@@ -70,9 +70,9 @@ describe("TransferScheduler", () => {
   it("rolls back an unfinished probe after a long gap", async () => {
     const h = harness();
     for (let batch = 0; batch < 4; batch += 1) await transferBatch(h);
-    expect(await transferBatch(h)).toBe(3);
+    expect(await transferBatch(h)).toBe(9);
     h.advance(10_000);
-    expect(await transferBatch(h)).toBe(2);
+    expect(await transferBatch(h)).toBe(8);
     await h.scheduler.dispose();
   });
 
@@ -85,80 +85,82 @@ describe("TransferScheduler", () => {
     h.controls.get(id)!.reject({ status: 403 });
     await expect(job).rejects.toEqual({ status: 403 });
     await flush();
-    expect(await transferBatch(h)).toBe(2);
-    expect(await transferBatch(h)).toBe(2);
+    expect(await transferBatch(h)).toBe(8);
+    expect(await transferBatch(h)).toBe(8);
     await h.scheduler.dispose();
   });
 
   it("bounds each direction independently and preserves FIFO admission", async () => {
     const h = harness();
-    const jobs = [h.add(1), h.add(2), h.add(3), h.add(4, "download"), h.add(5, "download")];
+    const jobs = Array.from({ length: 9 }, (_, i) => h.add(i));
+    jobs.push(h.add(9, "download"));
     await flush();
-    expect(h.started).toEqual([1, 2, 4, 5]);
+    expect(h.started).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 9]);
     h.controls.get(2)!.resolve({ value: 2, bytes: 100 });
     await flush();
-    expect(h.started).toEqual([1, 2, 4, 5, 3]);
-    for (const id of [1, 3, 4, 5]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
-    await expect(Promise.all(jobs)).resolves.toEqual([1, 2, 3, 4, 5]);
+    expect(h.started[h.started.length - 1]).toBe(8);
+    for (const id of h.started.filter(id => id !== 2)) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    await expect(Promise.all(jobs)).resolves.toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
   it("reduces admission after overload without cancelling active requests or retrying", async () => {
     const h = harness();
-    const jobs = [h.add(1), h.add(2), h.add(3)];
-    const results = Promise.allSettled(jobs);
+    const results = Promise.allSettled(Array.from({ length: 9 }, (_, i) => h.add(i)));
     await flush();
     const error = { status: 503 };
-    h.controls.get(1)!.reject(error);
+    h.controls.get(0)!.reject(error);
     await flush();
-    expect(h.started).toEqual([1, 2]);
-    h.controls.get(2)!.resolve({ value: 2, bytes: 100 });
+    for (const id of [1, 2, 3]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
     await flush();
-    expect(h.started).toEqual([1, 2, 3]);
-    h.controls.get(3)!.resolve({ value: 3, bytes: 100 });
+    expect(h.started).toHaveLength(8); // Four still active at the reduced limit.
+    h.controls.get(4)!.resolve({ value: 4, bytes: 100 });
+    await flush();
+    expect(h.started).toHaveLength(9);
+    for (const id of [5, 6, 7, 8]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
     expect((await results)[0]).toEqual({ status: "rejected", reason: error });
   });
 
   it.each([{ status: 401 }, { status: 403 }, { status: 413 }, new SyntaxError("invalid JSON")])(
     "does not treat application failures as congestion: %s", async error => {
       const h = harness();
-      const results = Promise.allSettled([h.add(1), h.add(2), h.add(3)]);
+      const results = Promise.allSettled(Array.from({ length: 9 }, (_, i) => h.add(i + 1)));
       await flush();
       h.controls.get(1)!.reject(error);
       await flush();
-      expect(h.started).toEqual([1, 2, 3]);
-      for (const id of [2, 3]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+      expect(h.started).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      for (const id of [2, 3, 4, 5, 6, 7, 8, 9]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
       await results;
     },
   );
 
   it("probes under sustained demand using wall-clock aggregate throughput", async () => {
     const h = harness();
-    const results = Promise.allSettled(Array.from({ length: 12 }, (_, id) => h.add(id)));
+    const results = Promise.allSettled(Array.from({ length: 24 }, (_, id) => h.add(id)));
     await flush();
     for (let id = 0; id < 4; id += 1) {
       h.advance(500);
       h.controls.get(id)!.resolve({ value: id, bytes: 100 });
       await flush();
     }
-    expect(h.started).toHaveLength(7); // Four finished, three now active.
+    expect(h.started).toHaveLength(13); // Four finished, nine now active.
     const closing = h.scheduler.dispose();
-    for (const id of [4, 5, 6]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    for (const id of [4, 5, 6, 7, 8, 9, 10, 11, 12]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
     await closing;
     await results;
   });
 
   it("rejects queued work on disposal and waits for active transfers", async () => {
     const h = harness();
-    const results = Promise.allSettled([h.add(1), h.add(2), h.add(3)]);
+    const results = Promise.allSettled(Array.from({ length: 9 }, (_, i) => h.add(i + 1)));
     await flush();
     let disposed = false;
     const closing = h.scheduler.dispose().then(() => { disposed = true; });
     await flush();
     expect(disposed).toBe(false);
-    expect(h.started).toEqual([1, 2]);
+    expect(h.started).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
     await expect(h.add(4)).rejects.toThrow("closed");
-    for (const id of [1, 2]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
+    for (const id of [1, 2, 3, 4, 5, 6, 7, 8]) h.controls.get(id)!.resolve({ value: id, bytes: 100 });
     await closing;
-    expect((await results)[2]?.status).toBe("rejected");
+    expect((await results)[8]?.status).toBe("rejected");
   });
 });


### PR DESCRIPTION
Short syncs can finish before the adaptive controller's first observation, leaving uploads and downloads at two concurrent transfers. Start at eight and continue probing without the ten-second cooldown after a successful throughput increase. Saturation rollback, overload backoff, and preparation caps remain in place.

Add four benchmark profiles that share one aggregate body-byte budget across transfers: upload/download at 2 MiB/s, and upload/download dropping to 512 KiB/s after one second. Keep the six quick profiles unchanged; include the new profiles in `bandwidth` and `full`. Add budget-sharing and capacity-transition tests, validate bandwidth configuration in reports, update admission tests, and refine the plugin release note.

Refs #38. Follow-up to #40; these measurements do not establish that the issue's reported upload failure is resolved.

## Performance

Compared with #40 (`6d80f83`) on the Node backend, using the same frozen benchmark driver for both revisions. One rehearsal and five measured samples per scenario and revision, alternating revision order with fresh processes. All 100 measured samples and 20 rehearsals passed file-content and sync-completion verification.

| Scenario | Baseline | Candidate | Change | Candidate range |
| --- | ---: | ---: | ---: | ---: |
| pull-notes-no-delay | 665.1 ms | 550.3 ms | -17.3% | 546.6–561.3 ms |
| pull-notes-page-40ms | 2161.8 ms | 712.7 ms | -67.0% | 698.5–727.1 ms |
| pull-notes-page-120ms | 2149.7 ms | 813.5 ms | -62.2% | 809.9–925.1 ms |
| push-mixed-no-delay | 598.0 ms | 499.9 ms | -16.4% | 473.7–560.5 ms |
| push-mixed-latency | 4993.5 ms | 1539.9 ms | -69.2% | 1460.7–1558.0 ms |
| push-mixed-slow-attachment | 5506.5 ms | 1574.2 ms | -71.4% | 1562.0–1634.2 ms |
| pull-mixed-bandwidth-2MiB | 7419.4 ms | 5710.0 ms | -23.0% | 5655.5–5760.3 ms |
| pull-mixed-bandwidth-drop | 17716.5 ms | 16822.7 ms | -5.0% | 16590.8–16930.8 ms |
| push-mixed-bandwidth-2MiB | 6812.9 ms | 4615.9 ms | -32.2% | 4603.5–4617.3 ms |
| push-mixed-bandwidth-drop | 16164.2 ms | 15238.0 ms | -5.7% | 15216.0–15299.3 ms |


At 2 MiB/s, upload note p95 fell from 6.63 s to 2.01 s; after the capacity drop it fell from 10.28 s to 2.42 s. These are medians of per-run file percentiles.

Tradeoff: median peak sampled whole-client RSS increased by about 25–33 MiB for delayed uploads, and 19–27 MiB for bandwidth-limited uploads. Measurements use local real HTTP/WebSocket servers, encrypted files, a Node filesystem client, and an in-memory store. Bandwidth is an application-level fair-sharing simulation, not kernel traffic shaping or TCP/socket backpressure. Results do not represent Obsidian/Dexie or mobile performance.

## Validation

- Sync client: 357 tests passed; typecheck passed.
- Obsidian plugin: 263 tests passed; typecheck passed.
- Benchmark driver: 19 tests passed; typecheck passed.
- Comparison: all 10 scenarios, five measurements per revision, plus rehearsals passed.
- `git diff --check origin/main...HEAD` passed.

Reproduce:

```sh
pnpm bench:sync:compare -- --base 6d80f83 --runtime node --suite quick --iterations 5 --warmup 1
pnpm bench:sync:compare -- --base 6d80f83 --runtime node --suite bandwidth --iterations 5 --warmup 1
```
